### PR TITLE
ci: fix sdist upload

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,7 +73,7 @@ jobs:
         run: |
           python -m pip install --upgrade wheel setuptools setuptools-rust
       - name: Build sdist
-        run: python setup.py bdist_wheel
+        run: python setup.py sdist
 
       - uses: actions/upload-artifact@v2
         with:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools_rust import Binding, RustExtension, Strip
 
 setup(
     name='fluvio',
-    version="0.9.5",
+    version="0.9.6-beta-0",
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
     author = "Fluvio Contributors",


### PR DESCRIPTION
It looks like the sdist job is not building a .tar.gz file, I think that this should fix that