### PR TITLE
Update to fluvio 0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,8 @@ dependencies = [
  "flapigen",
  "flate2",
  "fluvio",
- "fluvio-future 0.4.2",
+ "fluvio-future",
+ "fluvio-spu-schema",
  "log",
 ]
 
@@ -101,11 +102,12 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97a171d191782fba31bb902b14ad94e24a68145032b7eedf871ab0bc0d077b6"
+checksum = "c8101efe8695a6c17e02911402145357e718ac92d3ff88ae8419e84b1707b685"
 dependencies = [
  "event-listener",
+ "futures-lite",
 ]
 
 [[package]]
@@ -192,9 +194,9 @@ checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
 
 [[package]]
 name = "async-trait"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
+checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -237,9 +239,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "bitflags"
@@ -272,9 +274,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.11.0"
+version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
+checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
 name = "bytes"
@@ -328,6 +330,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,9 +365,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpython"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7d46ba8ace7f3a1d204ac5060a706d0a68de6b42eafb6a586cc08bebcffe664"
+checksum = "3052106c29da7390237bc2310c1928335733b286287754ea85e6093d2495280e"
 dependencies = [
  "libc",
  "num-traits",
@@ -383,20 +395,63 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
+checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
 name = "ctor"
-version = "0.1.23"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdffe87e1d521a10f9696f833fe502293ea446d7f256c06128293a4119bdf4cb"
+checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "cxx"
+version = "1.0.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b7d4e43b25d3c994662706a1d4fcfc32aaa6afd287502c111b237093bb23f3a"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84f8829ddc213e2c1368e51a2564c552b65a8cb6a28f31e576270ac81d5e5827"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e72537424b474af1460806647c41d4b6d35d09ef7fe031c5c2fa5766047cc56a"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "309e4fb93eed90e1e14bea0da16b209f81813ba9fc7830c20ed151dd7bc0a4d7"
+dependencies = [
+ "proc-macro2",
  "quote",
  "syn",
 ]
@@ -488,10 +543,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c07b7cc9cd8c08d10db74fca3b20949b9b6199725c04a0cce6d543496098fcac"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
+name = "enum-ordinalize"
+version = "3.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2170fc0efee383079a8bdd05d6ea2a184d2a0f07a1c1dcabdb2fd5e9f24bc36c"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
 
 [[package]]
 name = "env_logger"
@@ -570,9 +651,9 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef9777bb3fcc752a0edebcdac91a285ad40ed0aeced5f5992e4efb16a5eb7555"
+checksum = "fbff062a4c7484872c1a483bb7217de260b41ce00f36752fa3d9aea4bd308717"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -582,14 +663,15 @@ dependencies = [
  "built",
  "bytes",
  "cfg-if",
+ "chrono",
  "derive_builder",
  "dirs",
  "event-listener",
  "fluvio-compression",
- "fluvio-dataplane-protocol",
- "fluvio-future 0.4.2",
+ "fluvio-future",
  "fluvio-protocol",
  "fluvio-sc-schema",
+ "fluvio-smartmodule",
  "fluvio-socket",
  "fluvio-spu-schema",
  "fluvio-types",
@@ -608,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "fluvio-compression"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbef7d6100728824960ed3d3e6b242a1c467db2fd6e26374635981d0547c7e27"
+checksum = "14f1780798a46ba585d4c41626c19cb707d5b073bbf352f6dbbdeacd1986d449"
 dependencies = [
  "bytes",
  "flate2",
@@ -622,57 +704,22 @@ dependencies = [
 
 [[package]]
 name = "fluvio-controlplane-metadata"
-version = "0.15.4"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d876315d312d61a7822df10f60363a5ef396b40ea29b8ad4ab7ecfded7122e1"
+checksum = "36b9affdafec74a7b646beb850907b09b7e81fc0522803f918c8edae29eed880"
 dependencies = [
  "async-trait",
  "base64",
- "fluvio-dataplane-protocol",
- "fluvio-future 0.3.18",
+ "bytes",
+ "fluvio-future",
  "fluvio-protocol",
  "fluvio-stream-model",
  "fluvio-types",
  "flv-util",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "fluvio-dataplane-protocol"
-version = "0.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a691755125a8211290191dc46f6a2c07898d891c00c4e09ebbad735908afa35a"
-dependencies = [
- "bytes",
- "cfg-if",
- "chrono",
- "content_inspector",
- "crc32c",
- "eyre",
- "fluvio-compression",
- "fluvio-future 0.4.2",
- "fluvio-protocol",
- "fluvio-types",
- "flv-util",
- "futures-util",
- "once_cell",
+ "lenient_semver",
  "semver",
  "thiserror",
  "tracing",
-]
-
-[[package]]
-name = "fluvio-future"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e2d1fad8e412d44c516add2349a34f6d71d9279b108c8e012325ab17fcbf982"
-dependencies = [
- "fluvio-wasm-timer",
- "log",
- "thiserror",
- "tracing",
- "ws_stream_wasm",
 ]
 
 [[package]]
@@ -700,22 +747,31 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol"
-version = "0.7.9"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a5fa561c1628d40bdde2fbde33cb1ce4597386a3f943b45b09703bc3534cf2d"
+checksum = "06fa2854935ee5fc3c93dc0f4665354e487eec5d1a2342fc817dfda20ee7e745"
 dependencies = [
  "bytes",
- "fluvio-future 0.4.2",
+ "content_inspector",
+ "crc32c",
+ "eyre",
+ "fluvio-compression",
+ "fluvio-future",
  "fluvio-protocol-derive",
+ "fluvio-types",
+ "flv-util",
+ "once_cell",
+ "semver",
+ "thiserror",
  "tokio-util",
  "tracing",
 ]
 
 [[package]]
 name = "fluvio-protocol-derive"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e1b0457e0fd958a6a8f54a508fda58ba169ba667d3fe26367fa50eee4d733b"
+checksum = "e1dd5a390e6159c0eac091e8f5e4124374aea6b01a8fcffd5e249cdacbac4e1f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -725,12 +781,11 @@ dependencies = [
 
 [[package]]
 name = "fluvio-sc-schema"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdc8c0790b81d350c5bd787b9357da7d4021ab23b106526e31b76e9245af974b"
+checksum = "851cd3dc99efe8cff7f140a7bd10fabb7e4250dc72b0e3ae9bc205d0bc0687f8"
 dependencies = [
  "fluvio-controlplane-metadata",
- "fluvio-dataplane-protocol",
  "fluvio-protocol",
  "fluvio-types",
  "log",
@@ -741,10 +796,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "fluvio-socket"
-version = "0.12.1"
+name = "fluvio-smartmodule"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f29b8d7f99f3ac4d87579e13dfdf960ae2dc1523ca41313816e342da86be9f0"
+checksum = "61cdcbe01412492adadba2ee835c4e22678fcff8581b1b0fa1deb0b680d4e597"
+dependencies = [
+ "eyre",
+ "fluvio-protocol",
+ "fluvio-smartmodule-derive",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "fluvio-smartmodule-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1465b33d396d943cc819ae8cb2ad8e80998a974189320221a4c90e9439e062c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "fluvio-socket"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85d84122028b8a3d8326e840967b49cf404df3576b438f3af6b3fd45b1873cd0"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -752,7 +831,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "event-listener",
- "fluvio-future 0.4.2",
+ "fluvio-future",
  "fluvio-protocol",
  "futures-util",
  "once_cell",
@@ -765,14 +844,16 @@ dependencies = [
 
 [[package]]
 name = "fluvio-spu-schema"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4904b99254c7f7ec5e8b7d5518116e13ec091f8e2f8d8b630b2d4166e9c5b03"
+checksum = "70dff26adc3bc8b68909cc53762e88cd983b29303112ff204a6403e84b013fc7"
 dependencies = [
  "bytes",
+ "educe",
  "flate2",
- "fluvio-dataplane-protocol",
+ "fluvio-future",
  "fluvio-protocol",
+ "fluvio-smartmodule",
  "log",
  "serde",
  "static_assertions",
@@ -781,9 +862,9 @@ dependencies = [
 
 [[package]]
 name = "fluvio-stream-model"
-version = "0.6.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e421ff1be3b83020a3a97cb7ef8b6f045bca3b1eea2c95f0cea791eeeaaf988"
+checksum = "775f24ad3ec6e3965dc2c018670c8299b13a2115317e6cafbd29dfdbb29f62f2"
 dependencies = [
  "async-rwlock",
  "event-listener",
@@ -793,9 +874,9 @@ dependencies = [
 
 [[package]]
 name = "fluvio-types"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a675cf4a60aa0bff6f5d9d2c3c5201fc5a214cbb9e9d7f0127c7792314714bf"
+checksum = "03781d3cadb56c6c56c8539b07961902fa75dd13602efc3b174ea086060255ea"
 dependencies = [
  "event-listener",
  "thiserror",
@@ -859,9 +940,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
+checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -874,9 +955,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
+checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -884,15 +965,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
+checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
+checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -901,9 +982,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
+checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
 
 [[package]]
 name = "futures-lite"
@@ -922,9 +1003,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
+checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -933,21 +1014,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
+checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
 
 [[package]]
 name = "futures-task"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
+checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
 
 [[package]]
 name = "futures-util"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
+checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -963,9 +1044,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1013,15 +1094,26 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.49"
+version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bbaead50122b06e9a973ac20bc7445074d99ad9a0a0654934876908a9cec82c"
+checksum = "f5a6ef98976b22b3b7f2f3a806f858cb862044cfa66805aa3ad84cb3d3b785ed"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
+ "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
  "winapi",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
 ]
 
 [[package]]
@@ -1070,9 +1162,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
+checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
 name = "js-sys"
@@ -1099,10 +1191,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "libc"
-version = "0.2.133"
+name = "lenient_semver"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
+checksum = "de8de3f4f3754c280ce1c8c42ed8dd26a9c8385c2e5ad4ec5a77e774cea9c1ec"
+dependencies = [
+ "lenient_semver_parser",
+ "semver",
+]
+
+[[package]]
+name = "lenient_semver_parser"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f650c1d024ddc26b4bb79c3076b30030f2cf2b18292af698c81f7337a64d7d6"
+dependencies = [
+ "lenient_semver_version_builder",
+ "semver",
+]
+
+[[package]]
+name = "lenient_semver_version_builder"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9049f8ff49f75b946f95557148e70230499c8a642bf2d6528246afc7d0282d17"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.137"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "lock_api"
@@ -1149,6 +1279,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1175,9 +1316,9 @@ checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "openssl"
-version = "0.10.41"
+version = "0.10.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0"
+checksum = "12fc0523e3bd51a692c8850d075d74dc062ccf251c0110668cbd921917118a13"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1210,9 +1351,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.75"
+version = "0.9.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
+checksum = "b03b84c3b2d099b81f0953422b4d4ad58761589d0229b5506356afca05a3670a"
 dependencies = [
  "autocfg",
  "cc",
@@ -1319,15 +1460,15 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "polling"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899b00b9c8ab553c743b3e11e87c5c7d423b2a2de229ba95b24a756344748011"
+checksum = "ab4609a838d88b73d8238967b60dd115cc08d38e2bbaf51ee1e4b695f89122e2"
 dependencies = [
  "autocfg",
  "cfg-if",
@@ -1339,18 +1480,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "python3-sys"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b18b32e64c103d5045f44644d7ddddd65336f7a0521f6fde673240a9ecceb77e"
+checksum = "49f8b50d72fb3015735aa403eebf19bbd72c093bfeeae24ee798be5f2f1aab52"
 dependencies = [
  "libc",
  "regex",
@@ -1436,6 +1577,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "scratch"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
+
+[[package]]
 name = "semver"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1452,18 +1599,18 @@ checksum = "930c0acf610d3fdb5e2ab6213019aaa04e227ebe9547b0649ba599b16d788bd7"
 
 [[package]]
 name = "serde"
-version = "1.0.145"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
+checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.145"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
+checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1472,9 +1619,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.85"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
+checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
 dependencies = [
  "itoa",
  "ryu",
@@ -1517,9 +1664,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "smol_str"
@@ -1582,9 +1729,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52205623b1b0f064a4e71182c3b18ae902267282930c6d5462c91b859668426e"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1602,18 +1749,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.35"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c53f98874615aea268107765aa1ed8f6116782501d18e53d08b471733bea6c85"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.35"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8b463991b4eab2d801e724172285ec4195c650e8ec79b149e6c2a8e6dd3f783"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1648,9 +1795,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.21.1"
+version = "1.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0020c875007ad96677dcc890298f4b942882c5d4eb7cc8f439fc3bf813dc9c95"
+checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
 dependencies = [
  "autocfg",
  "pin-project-lite",
@@ -1694,9 +1841,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.36"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
@@ -1706,9 +1853,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1717,9 +1864,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
 ]
@@ -1742,9 +1889,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
 name = "unicode-normalization"
@@ -1754,6 +1901,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "_fluvio_python"
-version = "0.9.0"
+version = "0.14.0"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 
@@ -16,5 +16,6 @@ log = "^0.4.17"
 [dependencies]
 cpython = { version = "0.7", features = ["extension-module"] }
 flate2 = "1.0.24"
-fluvio = { version = "0.13" }
+fluvio = { version = "0.14" }
+fluvio-spu-schema = { version = "0.10.0", default-features = false }
 fluvio-future = { version = "0.4.2", features = ["task", "io"] }

--- a/macos-ci-tests/test_connect.py
+++ b/macos-ci-tests/test_connect.py
@@ -23,7 +23,7 @@ class TestFluvioCannotConnect(unittest.TestCase):
             error.args,
             [
                 (
-                    'Config error: Config has no active profile\nCaused by:\nConfig has no active profile',  # noqa: E501
+                    "Config error: Config has no active profile\nCaused by:\nConfig has no active profile",  # noqa: E501
                 ),
                 (
                     "Fluvio config error: Config has no active profile\nCaused by:\nConfig has no active profile",  # noqa: E501

--- a/macos-ci-tests/test_connect.py
+++ b/macos-ci-tests/test_connect.py
@@ -23,6 +23,9 @@ class TestFluvioCannotConnect(unittest.TestCase):
             error.args,
             [
                 (
+                    'Config error: Config has no active profile\nCaused by:\nConfig has no active profile',  # noqa: E501
+                ),
+                (
                     "Fluvio config error: Config has no active profile\nCaused by:\nConfig has no active profile",  # noqa: E501
                 ),
                 (

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools_rust import Binding, RustExtension, Strip
 
 setup(
     name='fluvio',
-    version="0.13.0",
+    version="0.14.0",
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
     author = "Fluvio Contributors",

--- a/src/glue.rs.in
+++ b/src/glue.rs.in
@@ -1,49 +1,3 @@
-use fluvio::{
-    Fluvio,
-    PartitionConsumer,
-    TopicProducer,
-    FluvioError,
-    dataplane::ErrorCode,
-    Offset,
-    consumer::Record,
-};
-use std::io::{Read, Error};
-use flate2::bufread::GzEncoder;
-use flate2::Compression;
-use fluvio_future::{
-    task::run_block_on,
-    io::{
-        Stream,
-        StreamExt,
-    },
-};
-use fluvio::consumer::{
-    SmartModuleInvocation,
-    SmartModuleInvocationWasm,
-    SmartModuleKind,
-    ConsumerConfig
-};
-use std::pin::Pin;
-
-mod _Fluvio {
-    use super::*;
-    pub fn connect() -> Result<Fluvio, FluvioError> {
-        run_block_on(Fluvio::connect())
-    }
-    pub fn partition_consumer(
-        fluvio: &Fluvio,
-        topic: String,
-        partition: i32
-    ) -> Result<PartitionConsumer, FluvioError> {
-        run_block_on(fluvio.partition_consumer(topic, partition))
-    }
-    pub fn topic_producer(
-        fluvio: &Fluvio,
-        topic: String,
-    ) -> Result<TopicProducer, FluvioError> {
-        run_block_on(fluvio.topic_producer(topic))
-    }
-}
 
 foreign_class!(class Fluvio {
     self_type Fluvio;
@@ -59,50 +13,6 @@ foreign_class!(class Fluvio {
         _: String
     ) -> Result<TopicProducer, FluvioError>;
 });
-
-
-pub struct ConsumerConfigWrapper {
-    wasm_module: Vec<u8>,
-}
-
-impl ConsumerConfigWrapper {
-    fn new_config_with_wasm_filter(file: &str) -> Result<ConsumerConfigWrapper, std::io::Error> {
-        let raw_buffer = std::fs::read(file)?;
-        let mut encoder = GzEncoder::new(raw_buffer.as_slice(), Compression::default());
-        let mut buffer = Vec::with_capacity(raw_buffer.len());
-        let encoder = encoder.read_to_end(&mut buffer)?;
-        Ok(ConsumerConfigWrapper {
-            wasm_module: buffer,
-        })
-    }
-}
-
-mod _PartitionConsumer {
-    use super::*;
-    pub fn stream(
-        consumer: &PartitionConsumer,
-        offset: &Offset,
-    ) -> Result<PartitionConsumerStream, FluvioError> {
-        Ok(PartitionConsumerStream {
-            inner: Box::pin(run_block_on(consumer.stream(offset.clone()))?)
-        })
-    }
-    pub fn stream_with_config(
-        consumer: &PartitionConsumer,
-        offset: &Offset,
-        wasm_module_path: &str
-    ) -> Result<PartitionConsumerStream, FluvioError> {
-        let config_wrapper = ConsumerConfigWrapper::new_config_with_wasm_filter(wasm_module_path)?;
-        let mut builder = ConsumerConfig::builder();
-        builder.smartmodule(Some(SmartModuleInvocation {
-            wasm: SmartModuleInvocationWasm::AdHoc(config_wrapper.wasm_module),
-            kind: SmartModuleKind::Filter,
-            params: Default::default()
-        }));
-        let config = builder.build().map_err(|err| FluvioError::Other(err.to_string()))?;
-        run_block_on(consumer.stream_with_config(offset.clone(), config)).map(|stream| PartitionConsumerStream { inner: Box::pin(stream) })
-    }
-}
 foreign_class!(class PartitionConsumer {
     self_type PartitionConsumer;
     private constructor = empty;
@@ -114,18 +24,6 @@ foreign_class!(class PartitionConsumer {
     ) -> Result<PartitionConsumerStream, FluvioError>;
 });
 
-type PartitionConsumerIteratorInner =
-    Pin<Box<dyn Stream<Item = Result<Record, ErrorCode>> + Send>>;
-
-pub struct PartitionConsumerStream {
-    pub inner: PartitionConsumerIteratorInner,
-}
-impl PartitionConsumerStream {
-    pub fn next(&mut self) -> Option<Result<Record, ErrorCode>> {
-        run_block_on(self.inner.next())
-    }
-}
-
 foreign_class!(class PartitionConsumerStream{
     self_type PartitionConsumerStream;
     private constructor = empty;
@@ -134,19 +32,6 @@ foreign_class!(class PartitionConsumerStream{
     ) -> Option<Result<Record, ErrorCode>>;
 });
 
-#[derive(Clone)]
-pub struct ProducerBatchRecord {
-    pub key: Vec<u8>,
-    pub value: Vec<u8>,
-}
-impl ProducerBatchRecord {
-    pub fn new(key: Vec<u8>, value: Vec<u8>) -> Self {
-        Self {
-            key,
-            value,
-        }
-    }
-}
 foreign_class!(
     #[derive(Clone)]
     class ProducerBatchRecord {
@@ -155,36 +40,6 @@ foreign_class!(
         fn ProducerBatchRecord::clone(&self) -> ProducerBatchRecord;
     }
 );
-
-mod _TopicProducer {
-    use super::*;
-    pub fn send(
-        producer: &TopicProducer,
-        key: &[u8],
-        value: &[u8],
-    ) -> Result<(), FluvioError> {
-        run_block_on(producer.send(key, value)).map(|_| ())
-    }
-    pub fn send_all(
-        producer: &TopicProducer,
-        records: &[ProducerBatchRecord],
-    ) -> Result<(), FluvioError> {
-        run_block_on(
-            producer.send_all(
-                records.iter().map(|record| -> (Vec<u8>, Vec<u8>) {
-                    (record.key.clone(), record.value.clone())
-                })
-            )
-        ).map(|_| ())
-    }
-    pub fn flush(
-        producer: &TopicProducer,
-    ) -> Result<(), FluvioError> {
-        run_block_on(
-            producer.flush()
-        )
-    }
-}
 
 foreign_class!(class TopicProducer {
     self_type TopicProducer;
@@ -202,21 +57,6 @@ foreign_class!(class TopicProducer {
         &self,
     ) -> Result<(), FluvioError>;
 });
-
-
-use std::string::FromUtf8Error;
-mod _Record {
-    use super::*;
-    pub fn value_string(record: &Record) -> Result<String, FromUtf8Error> {
-        String::from_utf8(record.value().to_vec())
-    }
-    pub fn key_string(
-        record: &Record
-    ) -> Option<Result<String, FromUtf8Error>> {
-        let key = record.key()?;
-        Some(String::from_utf8(key.to_vec()))
-    }
-}
 
 foreign_class!(class Record {
     self_type Record;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,138 @@
 #![allow(non_snake_case, unused)]
+use flate2::bufread::GzEncoder;
+use flate2::Compression;
+use fluvio::consumer::{
+    ConsumerConfig, SmartModuleInvocation, SmartModuleInvocationWasm, SmartModuleKind,
+};
+use fluvio::{
+    consumer::Record, dataplane::ErrorCode, Fluvio, FluvioError, Offset, PartitionConsumer,
+    TopicProducer,
+};
+use fluvio_future::{
+    io::{Stream, StreamExt},
+    task::run_block_on,
+};
+use std::io::{Error, Read};
+use std::pin::Pin;
+use std::string::FromUtf8Error;
+
+mod _Fluvio {
+    use super::*;
+    pub fn connect() -> Result<Fluvio, FluvioError> {
+        run_block_on(Fluvio::connect())
+    }
+    pub fn partition_consumer(
+        fluvio: &Fluvio,
+        topic: String,
+        partition: i32,
+    ) -> Result<PartitionConsumer, FluvioError> {
+        run_block_on(fluvio.partition_consumer(topic, partition))
+    }
+    pub fn topic_producer(fluvio: &Fluvio, topic: String) -> Result<TopicProducer, FluvioError> {
+        run_block_on(fluvio.topic_producer(topic))
+    }
+}
+
+pub struct ConsumerConfigWrapper {
+    wasm_module: Vec<u8>,
+}
+
+impl ConsumerConfigWrapper {
+    fn new_config_with_wasm_filter(file: &str) -> Result<ConsumerConfigWrapper, std::io::Error> {
+        let raw_buffer = std::fs::read(file)?;
+        let mut encoder = GzEncoder::new(raw_buffer.as_slice(), Compression::default());
+        let mut buffer = Vec::with_capacity(raw_buffer.len());
+        let encoder = encoder.read_to_end(&mut buffer)?;
+        Ok(ConsumerConfigWrapper {
+            wasm_module: buffer,
+        })
+    }
+}
+
+mod _PartitionConsumer {
+    use super::*;
+    pub fn stream(
+        consumer: &PartitionConsumer,
+        offset: &Offset,
+    ) -> Result<PartitionConsumerStream, FluvioError> {
+        Ok(PartitionConsumerStream {
+            inner: Box::pin(run_block_on(consumer.stream(offset.clone()))?),
+        })
+    }
+    pub fn stream_with_config(
+        consumer: &PartitionConsumer,
+        offset: &Offset,
+        wasm_module_path: &str,
+    ) -> Result<PartitionConsumerStream, FluvioError> {
+        let config_wrapper = ConsumerConfigWrapper::new_config_with_wasm_filter(wasm_module_path)?;
+        let mut builder = ConsumerConfig::builder();
+        builder.smartmodule(Some(SmartModuleInvocation {
+            wasm: SmartModuleInvocationWasm::AdHoc(config_wrapper.wasm_module),
+            kind: SmartModuleKind::Filter,
+            params: Default::default(),
+        }));
+        let config = builder
+            .build()
+            .map_err(|err| FluvioError::Other(err.to_string()))?;
+        run_block_on(consumer.stream_with_config(offset.clone(), config)).map(|stream| {
+            PartitionConsumerStream {
+                inner: Box::pin(stream),
+            }
+        })
+    }
+}
+
+type PartitionConsumerIteratorInner = Pin<Box<dyn Stream<Item = Result<Record, ErrorCode>> + Send>>;
+
+pub struct PartitionConsumerStream {
+    pub inner: PartitionConsumerIteratorInner,
+}
+impl PartitionConsumerStream {
+    pub fn next(&mut self) -> Option<Result<Record, ErrorCode>> {
+        run_block_on(self.inner.next())
+    }
+}
+#[derive(Clone)]
+pub struct ProducerBatchRecord {
+    pub key: Vec<u8>,
+    pub value: Vec<u8>,
+}
+impl ProducerBatchRecord {
+    pub fn new(key: Vec<u8>, value: Vec<u8>) -> Self {
+        Self { key, value }
+    }
+}
+
+mod _TopicProducer {
+    use super::*;
+    pub fn send(producer: &TopicProducer, key: &[u8], value: &[u8]) -> Result<(), FluvioError> {
+        run_block_on(producer.send(key, value)).map(|_| ())
+    }
+    pub fn send_all(
+        producer: &TopicProducer,
+        records: &[ProducerBatchRecord],
+    ) -> Result<(), FluvioError> {
+        run_block_on(
+            producer.send_all(records.iter().map(|record| -> (Vec<u8>, Vec<u8>) {
+                (record.key.clone(), record.value.clone())
+            })),
+        )
+        .map(|_| ())
+    }
+    pub fn flush(producer: &TopicProducer) -> Result<(), FluvioError> {
+        run_block_on(producer.flush())
+    }
+}
+
+mod _Record {
+    use super::*;
+    pub fn value_string(record: &Record) -> Result<String, FromUtf8Error> {
+        String::from_utf8(record.value().to_vec())
+    }
+    pub fn key_string(record: &Record) -> Option<Result<String, FromUtf8Error>> {
+        let key = record.key()?;
+        Some(String::from_utf8(key.to_vec()))
+    }
+}
 
 include!(concat!(env!("OUT_DIR"), "/glue.rs"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,15 @@
 use flate2::bufread::GzEncoder;
 use flate2::Compression;
 use fluvio::consumer::{
-    ConsumerConfig, SmartModuleInvocation, SmartModuleInvocationWasm, SmartModuleKind,
+    ConsumerConfig,
 };
+use fluvio::dataplane::link::ErrorCode;
 use fluvio::{
-    consumer::Record, dataplane::ErrorCode, Fluvio, FluvioError, Offset, PartitionConsumer,
+    consumer::Record, Fluvio, FluvioError, Offset, PartitionConsumer,
     TopicProducer,
+};
+use fluvio_spu_schema::server::smartmodule::{
+    SmartModuleInvocation, SmartModuleInvocationWasm, SmartModuleKind,
 };
 use fluvio_future::{
     io::{Stream, StreamExt},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,20 +1,15 @@
 #![allow(non_snake_case, unused)]
 use flate2::bufread::GzEncoder;
 use flate2::Compression;
-use fluvio::consumer::{
-    ConsumerConfig,
-};
+use fluvio::consumer::ConsumerConfig;
 use fluvio::dataplane::link::ErrorCode;
-use fluvio::{
-    consumer::Record, Fluvio, FluvioError, Offset, PartitionConsumer,
-    TopicProducer,
-};
-use fluvio_spu_schema::server::smartmodule::{
-    SmartModuleInvocation, SmartModuleInvocationWasm, SmartModuleKind,
-};
+use fluvio::{consumer::Record, Fluvio, FluvioError, Offset, PartitionConsumer, TopicProducer};
 use fluvio_future::{
     io::{Stream, StreamExt},
     task::run_block_on,
+};
+use fluvio_spu_schema::server::smartmodule::{
+    SmartModuleInvocation, SmartModuleInvocationWasm, SmartModuleKind,
 };
 use std::io::{Error, Read};
 use std::pin::Pin;


### PR DESCRIPTION
Most of this is actually a refactor to make rust-analyzer work nicely with this codebase. The actual changes were on the imports and adding `fluvio-spu-schema` as a dependency.