### PR TITLE
Updated flake8, pycodestyle, pyflacks, remove python 3.7 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         rust: [stable]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
@@ -113,7 +113,7 @@ jobs:
       matrix:
         os: [macos-latest]
         rust: [stable]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
       - name: Install ${{ matrix.rust }}

--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         rust: [stable]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest] # TODO: add windows-2019,
-        python-version: ["37", "38", "39", "310", "311"]
+        python-version: ["38", "39", "310", "311"]
     env:
       CIBW_SKIP: "cp36-* pp* *-win32"
       CIBW_ARCHS_MACOS: x86_64 universal2
@@ -142,7 +142,7 @@ jobs:
         run: |
           docker build -f cross/Dockerfile.${{ matrix.platform.target }} -t  fluvio-cross-python:${{ matrix.platform.target }} cross
       - name: Build bdist
-        run: python setup.py bdist_wheel --py-limited-api=cp37 --plat-name ${{ matrix.platform.name }}
+        run: python setup.py bdist_wheel --py-limited-api=cp38 --plat-name ${{ matrix.platform.name }}
         env:
             CARGO_BUILD_TARGET: ${{ matrix.platform.target }}
       - uses: actions/upload-artifact@v3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-flake8==5.0.4
+flake8==6.0.0
 mccabe==0.7.0
 msgpack==1.0.4
-pycodestyle==2.9.1
-pyflakes==2.5.0
+pycodestyle==2.10.0
+pyflakes==3.0.1
 black==22.10.0
 semantic-version==2.10.0
 setuptools-rust==1.5.2


### PR DESCRIPTION
Closes #197.
Supersedes #190, #189, #187.

This is slowing development of #180 so let's just remove python 3.7 support.