### PR TITLE
[Merged by Bors] - feat: added timestamp method to Record 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,8 +103,11 @@ jobs:
         run: |
           make build-dev
       - name: Test
-        run: |
-          make integration-tests
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          command: make integration-tests
 
   macos_simple_tests:
     name: MacOS Simple test

--- a/fluvio/__init__.py
+++ b/fluvio/__init__.py
@@ -42,6 +42,10 @@ class Record:
         """The UTF-8 decoded key for this record."""
         return self._inner.key_string()
 
+    def timestamp(self) -> int:
+        """Timestamp of this record."""
+        return self._inner.timestamp()
+
 
 class Offset:
     """Describes the location of an event stored in a Fluvio partition."""

--- a/integration-tests/test_fluvio_python.py
+++ b/integration-tests/test_fluvio_python.py
@@ -43,7 +43,7 @@ class CommonFluvioSmartModuleTestCase(unittest.TestCase):
 
         create_topic(self.topic)
 
-        # FIXME: without this the tests fail. Some topics get created but with offset -1 
+        # FIXME: without this the tests fail. Some topics get created but with offset -1
         import time
 
         time.sleep(1)

--- a/integration-tests/test_fluvio_python.py
+++ b/integration-tests/test_fluvio_python.py
@@ -484,6 +484,15 @@ class TestFluvioMethods(unittest.TestCase):
             self.assertEqual(i.key_string(), "foo")
             self.assertEqual(i.key(), list("foo".encode()))
 
+    def test_record_timestamp(self):
+        fluvio = Fluvio.connect()
+        producer = fluvio.topic_producer(self.topic)
+        producer.send_string("some_record")
+        producer.flush()
+        consumer = fluvio.partition_consumer(self.topic, 0)
+        record = next(consumer.stream(Offset.beginning()))
+        self.assertGreaterEqual(record.timestamp(), -1)
+
     def test_batch_produce(self):
         fluvio = Fluvio.connect()
         producer = fluvio.topic_producer(self.topic)

--- a/integration-tests/test_fluvio_python.py
+++ b/integration-tests/test_fluvio_python.py
@@ -9,22 +9,22 @@ import itertools
 def create_topic(topic):
     import subprocess
 
-    subprocess.run(["fluvio", "topic", "create", topic], shell=True).check_returncode()
+    subprocess.run(f"fluvio topic create {topic}", shell=True).check_returncode()
 
 
 def delete_topic(topic):
     import subprocess
 
-    subprocess.run(["fluvio", "topic", "delete", topic], shell=True).check_returncode()
+    subprocess.run(f"fluvio topic delete {topic}", shell=True).check_returncode()
 
 
 def create_smartmodule(sm_name, sm_path):
     import subprocess
 
     subprocess.run(
-        ["fluvio", "smartmodule", "create", sm_name, "--wasm-file", sm_path], shell=True
+        f"fluvio smartmodule create {sm_name} --wasm-file {sm_path}", shell=True
     ).check_returncode()
-    subprocess.run(["fluvio", "smartmodule", "list"], shell=True)
+    subprocess.run("fluvio smartmodule list", shell=True)
 
 
 def delete_smartmodule(sm_name):

--- a/src/glue.rs.in
+++ b/src/glue.rs.in
@@ -1,4 +1,3 @@
-
 foreign_class!(class Fluvio {
     self_type Fluvio;
     private constructor = empty;
@@ -46,6 +45,7 @@ foreign_class!(class Record {
     fn Record::offset(&self) -> i64;
     fn Record::value(&self) -> &[u8];
     fn Record::key(&self) -> Option<&[u8]>;
+    fn Record::timestamp(&self) -> i64;
     fn _Record::value_string(&self) -> Result<String, FromUtf8Error>;
     fn _Record::key_string(&self) -> Option<Result<String, FromUtf8Error>>;
 });


### PR DESCRIPTION
Closes #193

After adding the feature, I've also reinstalled the rust extension and ran this example:

```
#!/usr/bin/env python
# -*- coding: utf-8 -*-

from fluvio import Fluvio, Offset

fluvio = Fluvio.connect()
consumer = fluvio.partition_consumer("lobby", 0)
stream = consumer.stream(Offset.beginning())

for rec in stream:
    print(f"value: {rec.value_string()}, timestamp: {rec.timestamp()}")
```

```
❯ python examples/consumer.py 
value: hello, timestamp: 1668107698731
value: 1, timestamp: 1668107699960
value: 2, timestamp: 1668107699960
value: 3, timestamp: 1668107699960
value: 4, timestamp: 1668107699960
value: 5, timestamp: 1668107699961
value: 6, timestamp: 1668107699961
value: 7, timestamp: 1668107699961
value: 8, timestamp: 1668107699961
value: 9, timestamp: 1668107699961
value: 10, timestamp: 1668107699961
```
