### PR TITLE
feat: Implement `Fluvio::connect_with_config`, add `FluvioConfig`

### DIFF
--- a/fluvio/__init__.py
+++ b/fluvio/__init__.py
@@ -352,7 +352,7 @@ class Fluvio:
     @classmethod
     def connect_with_config(cls, config: FluvioConfig):
         """Creates a new Fluvio client using the given configuration"""
-        return cls(_Fluvio.connect_with_config(config))
+        return cls(_Fluvio.connect_with_config(config._inner))
 
     def partition_consumer(self, topic: str, partition: int) -> PartitionConsumer:
         """Creates a new `PartitionConsumer` for the given topic and partition

--- a/fluvio/__init__.py
+++ b/fluvio/__init__.py
@@ -1,5 +1,6 @@
 from ._fluvio_python import (
     Fluvio as _Fluvio,
+    FluvioConfig as _FluvioConfig,
     ConsumerConfig as _ConsumerConfig,
     PartitionConsumer as _PartitionConsumer,
     PartitionConsumerStream as _PartitionConsumerStream,
@@ -275,6 +276,49 @@ class TopicProducer:
         return self._inner.send_all(records_inner)
 
 
+class FluvioConfig:
+    """Configuration for Fluvio client"""
+
+    _inner: _FluvioConfig
+
+    def __init__(self, inner: _FluvioConfig):
+        self._inner = inner
+
+    @classmethod
+    def load(cls):
+        return cls(_FluvioConfig.load())
+
+    @classmethod
+    def new(cls, addr: str):
+        return cls(_FluvioConfig.new(addr))
+
+    def set_endpoint(self, endpoint: str):
+        self._inner.set_endpoint(endpoint)
+
+    def set_use_spu_local_address(self, val: bool):
+        self._inner.set_use_spu_local_address(val)
+
+    def disable_tls(self):
+        self._inner.disable_tls()
+
+    def set_anonymous_tls(self):
+        self._inner.set_anonymous_tls()
+
+    def set_inline_tls(self, domain: str, key: str, cert: str, ca_cert: str):
+        self._inner.set_inline_tls(domain, key, cert, ca_cert)
+
+    def set_tls_file_paths(
+        self, domain: str, key_path: str, cert_path: str, ca_cert_path: str
+    ):
+        self._inner.set_tls_file_paths(domain, key_path, cert_path, ca_cert_path)
+
+    def set_client_id(self, client_id: str):
+        self._inner.set_client_id(client_id)
+
+    def unset_client_id(self):
+        self._inner.unset_client_id()
+
+
 class Fluvio:
     """An interface for interacting with Fluvio streaming."""
 
@@ -294,6 +338,11 @@ class Fluvio:
         settings.
         """
         return cls(_Fluvio.connect())
+
+    @classmethod
+    def connect_with_config(cls, config: FluvioConfig):
+        """Creates a new Fluvio client using the given configuration"""
+        return cls(_Fluvio.connect_with_config(config))
 
     def partition_consumer(self, topic: str, partition: int) -> PartitionConsumer:
         """Creates a new `PartitionConsumer` for the given topic and partition

--- a/fluvio/__init__.py
+++ b/fluvio/__init__.py
@@ -286,36 +286,46 @@ class FluvioConfig:
 
     @classmethod
     def load(cls):
+        """get current cluster config from default profile"""
         return cls(_FluvioConfig.load())
 
     @classmethod
     def new(cls, addr: str):
+        """Create a new cluster configuration with no TLS."""
         return cls(_FluvioConfig.new(addr))
 
     def set_endpoint(self, endpoint: str):
+        """set endpoint"""
         self._inner.set_endpoint(endpoint)
 
     def set_use_spu_local_address(self, val: bool):
+        """set wheather to use spu local address"""
         self._inner.set_use_spu_local_address(val)
 
     def disable_tls(self):
+        """disable tls for this config"""
         self._inner.disable_tls()
 
     def set_anonymous_tls(self):
+        """set the config to use anonymous tls"""
         self._inner.set_anonymous_tls()
 
     def set_inline_tls(self, domain: str, key: str, cert: str, ca_cert: str):
+        """specify inline tls parameters"""
         self._inner.set_inline_tls(domain, key, cert, ca_cert)
 
     def set_tls_file_paths(
         self, domain: str, key_path: str, cert_path: str, ca_cert_path: str
     ):
+        """specify paths to tls files"""
         self._inner.set_tls_file_paths(domain, key_path, cert_path, ca_cert_path)
 
     def set_client_id(self, client_id: str):
+        """set client id"""
         self._inner.set_client_id(client_id)
 
     def unset_client_id(self):
+        """remove the configured client id from config"""
         self._inner.unset_client_id()
 
 

--- a/integration-tests/test_fluvio_python.py
+++ b/integration-tests/test_fluvio_python.py
@@ -1,5 +1,5 @@
 from string import ascii_lowercase
-from fluvio import Fluvio, Offset, ConsumerConfig, SmartModuleKind
+from fluvio import Fluvio, Offset, ConsumerConfig, SmartModuleKind, FluvioConfig
 import unittest
 import uuid
 import os
@@ -372,6 +372,10 @@ class TestFluvioMethods(CommonFluvioSmartModuleTestCase):
     def test_connect(self):
         # A very simple test
         Fluvio.connect()
+
+    def test_connect_with_config(self):
+        config = FluvioConfig.load()
+        Fluvio.connect_with_config(config)
 
     def test_produce(self):
         fluvio = Fluvio.connect()

--- a/src/glue.rs.in
+++ b/src/glue.rs.in
@@ -2,6 +2,7 @@ foreign_class!(class Fluvio {
     self_type Fluvio;
     private constructor = empty;
     fn _Fluvio::connect() -> Result<Fluvio, FluvioError>;
+    fn _Fluvio::connect_with_config(config: &FluvioConfig) -> Result<Fluvio, FluvioError>;
     fn _Fluvio::partition_consumer(
         &self,
         _: String,
@@ -11,6 +12,21 @@ foreign_class!(class Fluvio {
         &self,
         _: String
     ) -> Result<TopicProducer, FluvioError>;
+});
+
+foreign_class!(class FluvioConfig {
+    self_type FluvioConfig;
+    private constructor = empty;
+    fn FluvioConfig::load() -> Result<FluvioConfig, FluvioError>;
+    fn FluvioConfig::new(addr: &str) -> FluvioConfig;
+    fn FluvioConfig::set_endpoint(&mut self, endpoint: &str);
+    fn FluvioConfig::set_use_spu_local_address(&mut self, val: bool);
+    fn FluvioConfig::disable_tls(&mut self);
+    fn FluvioConfig::set_anonymous_tls(&mut self);
+    fn FluvioConfig::set_inline_tls(&mut self, domain: &str, key: &str, cert: &str, ca_cert: &str);
+    fn FluvioConfig::set_tls_file_paths(&mut self, domain: &str, key_path: &str, cert_path: &str, ca_cert_path: &str);
+    fn FluvioConfig::set_client_id(&mut self, id: &str);
+    fn FluvioConfig::unset_client_id(&mut self);
 });
 
 foreign_class!(


### PR DESCRIPTION
This PR adds the `Fluvio::connect_with_config` method. It also adds `FluvioConfig` structure to be used along with the added method.

closes https://github.com/infinyon/fluvio-client-python/issues/287