### PR TITLE
chore: fluvio-cloud-ci fix profile cfg

### DIFF
--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -48,6 +48,8 @@ jobs:
       - name: Login to fluvio cloud
         run: |
           fluvio cloud login --email ${FLUVIO_CLOUD_TEST_USERNAME} --password ${FLUVIO_CLOUD_TEST_PASSWORD} --remote 'https://dev.infinyon.cloud'
+          # add profile
+          fluvio cloud cluster sync
         env:
           FLUVIO_CLOUD_TEST_USERNAME: ${{ secrets.FLUVIO_CLOUD_TEST_USERNAME }}
           FLUVIO_CLOUD_TEST_PASSWORD: ${{ secrets.FLUVIO_CLOUD_TEST_PASSWORD }}


### PR DESCRIPTION
`fluvio cloud 0.2.17` is multi cluster so it does not default to creating a cluster profile 
Add a sync command to create a profile in ci