### PR TITLE
fix: change to recommended dev build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ install-wheel: build-wheel
 	$(PIP) install --upgrade --force-reinstall --no-index --pre --find-links=dist/ fluvio
 
 build-dev: venv-pip
-	$(PYTHON) setup.py develop
+	$(PIP) install -e .
 
 integration-tests: build-dev
 	cd integration-tests/ && $(PYTHON) -m unittest


### PR DESCRIPTION
Change from deprecated "python setup.py develop" to "pip install -e ."

This removes annoying deprecated setup.py message (for which direct
calling is deprecated not setup.py itself?)

https://github.com/pypa/setuptools/issues/917#issuecomment-1759240469
