### PR TITLE
Revert "fix: change to recommended dev build (#396)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ install-wheel: build-wheel
 	$(PIP) install --upgrade --force-reinstall --no-index --pre --find-links=dist/ fluvio
 
 build-dev: venv-pip
-	$(PIP) install -e .
+	$(PYTHON) setup.py develop
 
 integration-tests: build-dev
 	cd integration-tests/ && $(PYTHON) -m unittest


### PR DESCRIPTION
This reverts commit 83b4fc005563b2b2dc1c8a37a6ca7c0da3601e54.

The reverted commit and https://github.com/infinyon/fluvio-client-python/pull/393
seem to be incompatible, reverting this for now.
