### PR TITLE
chore: use admin module instead of cli in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,16 +75,21 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: AbsaOSS/k3d-action@v2
-        name: "Create fluvio k3d Cluster"
-        with:
-          cluster-name: "fluvio"
-      - name: Sleep 20 to ensure k3d cluster is ready
-        run: sleep 20
-      - name: Install Fluvio Cluster on k3d
+      # - uses: AbsaOSS/k3d-action@v2
+      #   name: "Create fluvio k3d Cluster"
+      #   with:
+      #     cluster-name: "fluvio"
+      # - name: Sleep 20 to ensure k3d cluster is ready
+      #   run: sleep 20
+      # - name: Install Fluvio Cluster on k3d
+      #   uses: infinyon/fluvio@master
+      #   with:
+      #     cluster-type: k3d
+      #     version: stable
+      - name: Install local Fluvio Cluster
         uses: infinyon/fluvio@master
         with:
-          cluster-type: k3d
+          cluster-type: local
           version: stable
       - name: Check Fluvio Installation
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,8 @@ jobs:
           timeout_minutes: 15
           max_attempts: 3
           command: make integration-tests
+        env:
+          FLV_SOCKET_WAIT: 300
 
   macos_simple_tests:
     name: MacOS Simple test

--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -56,6 +56,8 @@ jobs:
       - name: Run unit tests
         run: |
           make integration-tests
+        env:
+          FLV_SOCKET_WAIT: 300
 
       - name: Slack Notification
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         rust: [stable]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4

--- a/.github/workflows/latest-dev-fluvio.yaml
+++ b/.github/workflows/latest-dev-fluvio.yaml
@@ -68,6 +68,8 @@ jobs:
       - name: Test
         run: |
           make integration-tests
+        env:
+          FLV_SOCKET_WAIT: 300
 
       - name: Slack Notification
         uses: 8398a7/action-slack@v3

--- a/fluvio/__init__.py
+++ b/fluvio/__init__.py
@@ -868,7 +868,16 @@ class FluvioAdmin:
     def connect_with_config(config: FluvioConfig):
         return FluvioAdmin(_FluvioAdmin.connect_with_config(config._inner))
 
-    def create_topic(self, topic: str, dry_run: bool, spec: TopicSpec):
+    def create_topic(self, topic: str):
+
+        partitions = 1
+        replication = 1
+        ignore_rack = True
+        spec = _TopicSpec.new_computed(partitions, replication, ignore_rack)
+        dry_run = False
+        return self._inner.create_topic(topic, dry_run, spec)
+
+    def create_topic_spec(self, topic: str, dry_run: bool, spec: TopicSpec):
         return self._inner.create_topic(topic, dry_run, spec._inner)
 
     def create_topic_with_config(
@@ -893,19 +902,19 @@ class FluvioAdmin:
     def watch_topic(self) -> typing.Iterator[MetadataTopicSpec]:
         return self._topic_spec_generator(self._inner.watch_topic())
 
-    def create_smart_module(self, name: str, path: str, dry_run: bool):
+    def create_smartmodule(self, name: str, path: str, dry_run: bool):
         spec = SmartModuleSpec.new(path)
         return self._inner.create_smart_module(name, dry_run, spec._inner)
 
-    def delete_smart_module(self, name: str):
+    def delete_smartmodule(self, name: str):
         return self._inner.delete_smart_module(name)
 
-    def list_smart_modules(
+    def list_smartmodules(
         self, filters: typing.List[str]
     ) -> typing.List[MetadataSmartModuleSpec]:
         return self._inner.list_smart_modules(filters)
 
-    def watch_smart_module(self) -> typing.Iterator[MetadataSmartModuleSpec]:
+    def watch_smartmodule(self) -> typing.Iterator[MetadataSmartModuleSpec]:
         return self._smart_module_spec_generator(self._inner.watch_smart_module())
 
     def list_partitions(

--- a/integration-tests/test_fluvio_python.py
+++ b/integration-tests/test_fluvio_python.py
@@ -69,7 +69,6 @@ class CommonAsyncFluvioSmartModuleTestCase(unittest.IsolatedAsyncioTestCase):
             self.admin.create_topic(self.topic)
 
         # FIXME: without this the tests fail. Some topics get created but with offset -1
-        import time
         time.sleep(2)
 
     def setUp(self):

--- a/integration-tests/test_fluvio_python.py
+++ b/integration-tests/test_fluvio_python.py
@@ -783,12 +783,16 @@ class TestFluvioAdminTopic(CommonFluvioAdminTestCase):
         smart_modules = fluvio_admin.list_smartmodules([self.sm_name])
         self.assertEqual(len(smart_modules), 0)
 
-    # this test can fail because other failures from other runs can
-    # leave partitions dangling
     def test_admin_paritions(self):
         fluvio_admin = FluvioAdmin.connect()
+
+        topic = str(uuid.uuid4())
+        fluvio_admin.create_topic(topic)
 
         # list partitions
         all_partitions = fluvio_admin.list_partitions([])
         print(all_partitions)
-        self.assertNotEqual(len(all_partitions), self.num_partitions_start)
+        self.assertNotEqual(len(all_partitions), 0)
+
+        fluvio_admin.delete_topic(topic)
+

--- a/integration-tests/test_fluvio_python.py
+++ b/integration-tests/test_fluvio_python.py
@@ -76,6 +76,7 @@ class CommonAsyncFluvioSmartModuleTestCase(unittest.IsolatedAsyncioTestCase):
 
     def tearDown(self):
         self.admin.delete_topic(self.topic)
+        time.sleep(1)
         if self.sm_path is not None:
             self.admin.delete_smartmodule(self.sm_name)
 

--- a/integration-tests/test_fluvio_python.py
+++ b/integration-tests/test_fluvio_python.py
@@ -61,11 +61,15 @@ class CommonAsyncFluvioSmartModuleTestCase(unittest.IsolatedAsyncioTestCase):
         if sm_path is not None:
             create_smartmodule(self.sm_name, sm_path)
 
-        self.admin.create_topic(self.topic)
+        try:
+            self.admin.create_topic(self.topic)
+        except Exception as err:
+            print("Retrying after create_topic error {}", err)
+            time.sleep(5)
+            self.admin.create_topic(self.topic)
 
         # FIXME: without this the tests fail. Some topics get created but with offset -1
         import time
-
         time.sleep(2)
 
     def setUp(self):
@@ -792,7 +796,12 @@ class TestFluvioAdminTopic(CommonFluvioAdminTestCase):
         fluvio_admin = FluvioAdmin.connect()
 
         topic = str(uuid.uuid4())
-        fluvio_admin.create_topic(topic)
+        try:
+            fluvio_admin.create_topic(topic)
+        except Exception as err:
+            print("Retrying after create_topic error {}", err)
+            time.sleep(5)
+            fluvio_admin.create_topic(topic)
 
         # list partitions
         all_partitions = fluvio_admin.list_partitions([])

--- a/integration-tests/test_fluvio_python.py
+++ b/integration-tests/test_fluvio_python.py
@@ -34,7 +34,12 @@ class CommonFluvioSmartModuleTestCase(unittest.TestCase):
             # FIXME: without this the tests fail. Some topics get created but with offset -1
             time.sleep(2)
 
-        self.admin.create_topic(self.topic)
+        try:
+            self.admin.create_topic(self.topic)
+        except Exception as err:
+            print("Retrying after create_topic error {}", err)
+            time.sleep(5)
+            self.admin.create_topic(self.topic)
 
     def setUp(self):
         self.common_setup()

--- a/integration-tests/test_fluvio_python.py
+++ b/integration-tests/test_fluvio_python.py
@@ -795,4 +795,3 @@ class TestFluvioAdminTopic(CommonFluvioAdminTestCase):
         self.assertNotEqual(len(all_partitions), 0)
 
         fluvio_admin.delete_topic(topic)
-

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools_rust import Binding, RustExtension, Strip
 
 setup(
     name="fluvio",
-    version="0.16.2",
+    version="0.16.3",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
     author="Fluvio Contributors",


### PR DESCRIPTION
this also may fix some test failures due
to improved concurrency in the fluvio python client

