### PR TITLE
fix: publish build wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,64 @@ on:
     branches: [main]
 
 jobs:
+  ci_build_wheels:
+    name: Build wheels on ${{ matrix.os }} for Python ${{matrix.python-version}}.
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest] # TODO: add windows-2019,
+        python-version: ["38", "39", "310", "311", "312"]
+    env:
+      CIBW_SKIP: "cp36-* pp* *-win32"
+      CIBW_ARCHS_MACOS: x86_64 universal2
+      CIBW_ARCHS_LINUX: auto aarch64
+      CIBW_BEFORE_ALL_LINUX: "{package}/tools/cibw_before_all_linux.sh"
+      CIBW_BUILD_VERBOSITY: 1
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
+            target/
+          key: ${{ matrix.os }}-cargo-${{matrix.python-version}}-${{ hashFiles('**/Cargo.lock') }}
+
+      # Used to host cibuildwheel
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - if: runner.os == 'macOS'
+        name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          targets: aarch64-apple-darwin, x86_64-apple-darwin
+          toolchain: stable
+
+      - if: runner.os != 'Linux'
+        name: Setup env when not using docker
+        run: |
+          python -m pip install --upgrade wheel setuptools setuptools-rust
+
+      - if: runner.os == 'Linux'
+        name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+
+      - name: Build wheels for ${{matrix.python-version}} on ${{matrix.os}}
+        uses: pypa/cibuildwheel@v2.20.0
+        env:
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+          CIBW_BUILD: "cp${{matrix.python-version}}-manylinux_x86_64 cp${{matrix.python-version}}-macosx_x86_64 cp${{matrix.python-version}}-macosx_universal2 cp${{matrix.python-version}}-macosx_arm64"
+
   ci_build_cc_wheels:
     name: Cross Build wheels for ${{ matrix.platform.name }}
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,6 +62,7 @@ jobs:
       - name: Build wheels for ${{matrix.python-version}} on ${{matrix.os}}
         uses: pypa/cibuildwheel@v2.20.0
         env:
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           CIBW_BUILD: "cp${{matrix.python-version}}-manylinux_x86_64 cp${{matrix.python-version}}-macosx_x86_64 cp${{matrix.python-version}}-macosx_universal2 cp${{matrix.python-version}}-macosx_arm64"
 
       - uses: actions/upload-artifact@v4

--- a/tools/cibw_before_all_linux.sh
+++ b/tools/cibw_before_all_linux.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e -x
 
-yum install -y openssl-devel perl-IPC-Cmd
+yum install -y openssl-devel perl-IPC-Cmd clang-devel
 curl https://sh.rustup.rs --proto '=https' --tlsv1.2 -sSf | sh -s -- --default-toolchain stable -y
 cp $HOME/.cargo/bin/* /bin/


### PR DESCRIPTION
use new images to build wheels because the old one it was not identifying clang.