### PR TITLE
feat: improve topic creation api

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,15 @@ jobs:
       - name: Build
         run: |
           make build-dev
-      - name: Test
+      - name: Unit Tests
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          command: make unit-tests
+        env:
+          FLV_SOCKET_WAIT: 300
+      - name: Integration Tests
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,11 @@ jobs:
         python-version: ["39", "310", "311", "312"]
     env:
       CIBW_SKIP: "cp36-* pp* *-win32"
-      CIBW_ARCHS_MACOS: x86_64 universal2
+      CIBW_ARCHS_MACOS: x86_64 universal2 arm64
       CIBW_ARCHS_LINUX: auto aarch64
       CIBW_BEFORE_ALL_LINUX: "{package}/tools/cibw_before_all_linux.sh"
       CIBW_BUILD_VERBOSITY: 1
+      MACOSX_DEPLOYMENT_TARGET: 10.13
 
     steps:
       - uses: actions/checkout@v4
@@ -65,7 +66,7 @@ jobs:
           platforms: all
 
       - name: Build wheels for ${{matrix.python-version}} on ${{matrix.os}}
-        uses: pypa/cibuildwheel@v2.20.0
+        uses: pypa/cibuildwheel@v2.22.0
         env:
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           CIBW_BUILD: "cp${{matrix.python-version}}-manylinux_x86_64 cp${{matrix.python-version}}-macosx_x86_64 cp${{matrix.python-version}}-macosx_universal2 cp${{matrix.python-version}}-macosx_arm64"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,10 +15,11 @@ jobs:
         python-version: ["38", "39", "310", "311", "312"]
     env:
       CIBW_SKIP: "cp36-* pp* *-win32"
-      CIBW_ARCHS_MACOS: x86_64 universal2
+      CIBW_ARCHS_MACOS: x86_64 universal2 arm64
       CIBW_ARCHS_LINUX: auto aarch64
       CIBW_BEFORE_ALL_LINUX: "{package}/tools/cibw_before_all_linux.sh"
       CIBW_BUILD_VERBOSITY: 1
+      MACOSX_DEPLOYMENT_TARGET: 10.13
 
     steps:
       - uses: actions/checkout@v4
@@ -60,7 +61,7 @@ jobs:
           platforms: arm64
 
       - name: Build wheels for ${{matrix.python-version}} on ${{matrix.os}}
-        uses: pypa/cibuildwheel@v2.20.0
+        uses: pypa/cibuildwheel@v2.22.0
         env:
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           CIBW_BUILD: "cp${{matrix.python-version}}-manylinux_x86_64 cp${{matrix.python-version}}-macosx_x86_64 cp${{matrix.python-version}}-macosx_universal2 cp${{matrix.python-version}}-macosx_arm64"

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,9 @@ install-wheel: build-wheel
 build-dev: venv-pip
 	$(PYTHON) setup.py develop
 
+unit-tests: build-dev
+	cd tests/ && $(PYTHON) -m unittest
+
 integration-tests: build-dev
 	cd integration-tests/ && $(PYTHON) -m unittest
 

--- a/fluvio/__init__.py
+++ b/fluvio/__init__.py
@@ -72,7 +72,7 @@ from ._fluvio_python import (
 
 from ._fluvio_python import Error as FluviorError  # noqa: F401
 
-from .new_topic import NewTopic, CompressionType, TopicMode
+from .topic import TopicSpec, CompressionType, TopicMode
 from .record import Record, RecordMetadata
 from .specs import (
     # support types
@@ -80,7 +80,6 @@ from .specs import (
     PartitionMap,
     # specs
     SmartModuleSpec,
-    TopicSpec,
     MessageMetadataTopicSpec,
     MetadataPartitionSpec,
     MetadataSmartModuleSpec,
@@ -98,8 +97,8 @@ __all__ = [
     "Fluvio",
     "FluvioConfig",
     "FluvioAdmin",
-    # new_topic
-    "NewTopic",
+    # topic
+    "TopicSpec",
     "CompressionType",
     "TopicMode",
     # record
@@ -737,22 +736,22 @@ class FluvioAdmin:
     def connect_with_config(config: FluvioConfig):
         return FluvioAdmin(_FluvioAdmin.connect_with_config(config._inner))
 
-    def create_topic(self, topic: str, spec: typing.Optional[TopicSpec] = None):
+    def create_topic(self, topic: str, spec: typing.Optional[_TopicSpec] = None):
         partitions = 1
         replication = 1
         ignore_rack = True
         dry_run = False
-        spec_inner = (
-            spec._inner
+        spec = (
+            spec
             if spec is not None
             else _TopicSpec.new_computed(partitions, replication, ignore_rack)
         )
-        return self._inner.create_topic(topic, dry_run, spec_inner)
+        return self._inner.create_topic(topic, dry_run, spec)
 
     def create_topic_with_config(
-        self, topic: str, req: CommonCreateRequest, spec: TopicSpec
+        self, topic: str, req: CommonCreateRequest, spec: _TopicSpec
     ):
-        return self._inner.create_topic_with_config(topic, req._inner, spec._inner)
+        return self._inner.create_topic_with_config(topic, req._inner, spec)
 
     def delete_topic(self, topic: str):
         return self._inner.delete_topic(topic)

--- a/fluvio/__init__.py
+++ b/fluvio/__init__.py
@@ -72,6 +72,7 @@ from ._fluvio_python import (
 
 from ._fluvio_python import Error as FluviorError  # noqa: F401
 
+from .new_topic import NewTopic, CompressionType, TopicMode
 from .record import Record, RecordMetadata
 from .specs import (
     # support types
@@ -97,6 +98,11 @@ __all__ = [
     "Fluvio",
     "FluvioConfig",
     "FluvioAdmin",
+    # new_topic
+    "NewTopic",
+    "CompressionType",
+    "TopicMode",
+    # record
     "Record",
     "RecordMetadata",
     "Offset",
@@ -731,17 +737,17 @@ class FluvioAdmin:
     def connect_with_config(config: FluvioConfig):
         return FluvioAdmin(_FluvioAdmin.connect_with_config(config._inner))
 
-    def create_topic(self, topic: str):
-
+    def create_topic(self, topic: str, spec: typing.Optional[TopicSpec] = None):
         partitions = 1
         replication = 1
         ignore_rack = True
-        spec = _TopicSpec.new_computed(partitions, replication, ignore_rack)
         dry_run = False
-        return self._inner.create_topic(topic, dry_run, spec)
-
-    def create_topic_spec(self, topic: str, dry_run: bool, spec: TopicSpec):
-        return self._inner.create_topic(topic, dry_run, spec._inner)
+        spec_inner = (
+            spec._inner
+            if spec is not None
+            else _TopicSpec.new_computed(partitions, replication, ignore_rack)
+        )
+        return self._inner.create_topic(topic, dry_run, spec_inner)
 
     def create_topic_with_config(
         self, topic: str, req: CommonCreateRequest, spec: TopicSpec

--- a/fluvio/new_topic.py
+++ b/fluvio/new_topic.py
@@ -1,0 +1,124 @@
+from dataclasses import dataclass, replace
+from typing import Optional, List, Union
+from enum import Enum
+from .specs import TopicSpec, PartitionMap
+from .utils import parse_byte_size
+from humanfriendly import parse_timespan
+
+
+class TopicMode(Enum):
+    MIRROR = "mirror"
+    ASSIGNED = "assigned"
+    COMPUTED = "computed"
+
+
+class CompressionType(Enum):
+    NONE = "none"
+    GZIP = "gzip"
+    SNAPPY = "snappy"
+    LZ4 = "lz4"
+    ANY = "any"
+    ZSTD = "zstd"
+
+
+@dataclass(frozen=True)
+class NewTopic:
+    mode: TopicMode = TopicMode.COMPUTED
+    partitions: int = 1
+    replications: int = 1
+    ignore_rack: bool = False
+    replica_assignment: Optional[List[PartitionMap]] = None
+    retention_time: Optional[int] = None
+    segment_size: Optional[int] = None
+    compression_type: Optional[CompressionType] = None
+    max_partition_size: Optional[int] = None
+    system: bool = False
+
+    @classmethod
+    def create(cls) -> "NewTopic":
+        """Alternative constructor method"""
+        return cls()
+
+    def with_assignment(self, replica_assignment: List[PartitionMap]) -> "NewTopic":
+        """Set the assigned replica configuration"""
+        return replace(
+            self, mode=TopicMode.ASSIGNED, replica_assignment=replica_assignment
+        )
+
+    def as_mirror_topic(self) -> "NewTopic":
+        """Set as a mirror topic"""
+        return replace(self, mode=TopicMode.MIRROR)
+
+    def with_partitions(self, partitions: int) -> "NewTopic":
+        """Set the specified partitions"""
+        if partitions < 0:
+            raise ValueError("Partitions must be a positive integer")
+        return replace(self, partitions=partitions)
+
+    def with_replications(self, replications: int) -> "NewTopic":
+        """Set the specified replication factor"""
+        if replications < 0:
+            raise ValueError("Replication factor must be a positive integer")
+        return replace(self, replications=replications)
+
+    def with_ignore_rack(self, ignore: bool = True) -> "NewTopic":
+        """Set the rack ignore setting"""
+        return replace(self, ignore_rack=ignore)
+
+    def with_compression(self, compression: CompressionType) -> "NewTopic":
+        """Set the specified compression type"""
+        return replace(self, compression_type=compression)
+
+    def with_retention_time(self, retention_time: Union[str, int]) -> "NewTopic":
+        """Set the specified retention time"""
+
+        if isinstance(retention_time, int):
+            return replace(self, retention_time=retention_time)
+
+        parsed_time = parse_timespan(retention_time)
+        return replace(self, retention_time=parsed_time)
+
+    def with_segment_size(self, size: Union[str, int]) -> "NewTopic":
+        """Set the specified segment size"""
+        if isinstance(size, int):
+            return replace(self, segment_size=size)
+
+        parsed_size = parse_byte_size(size)
+        return replace(self, segment_size=parsed_size)
+
+    def with_max_partition_size(self, size: Union[str, int]) -> "NewTopic":
+        """Set the specified max partition size"""
+        if isinstance(size, int):
+            return replace(self, max_partition_size=size)
+
+        parsed_size = parse_byte_size(size)
+        return replace(self, max_partition_size=parsed_size)
+
+    def as_system_topic(self, is_system: bool = True) -> "NewTopic":
+        """Set the topic as an internal system topic"""
+        return replace(self, system=is_system)
+
+    def build(self) -> TopicSpec:
+        """Build the TopicSpec based on the current configuration"""
+        # Similar implementation to the original build method
+        if self.mode == TopicMode.ASSIGNED and self.replica_assignment:
+            spec = TopicSpec.new_assigned(self.replica_assignment)
+        elif self.mode == TopicMode.MIRROR:
+            spec = TopicSpec.new_mirror()
+        else:
+            spec = TopicSpec.new_computed(
+                self.partitions, self.replications, self.ignore_rack
+            )
+
+        spec.set_system(self.system)
+
+        if self.retention_time is not None:
+            spec.set_retention_time(self.retention_time)
+
+        if self.max_partition_size is not None or self.segment_size is not None:
+            spec.set_storage(self.max_partition_size, self.segment_size)
+
+        if self.compression_type is not None:
+            spec.set_compression_type(self.compression_type.value)
+
+        return spec

--- a/fluvio/specs.py
+++ b/fluvio/specs.py
@@ -33,13 +33,35 @@ class TopicSpec:
         self._inner = inner
 
     @classmethod
-    def new_assigned(cls, partition_maps: typing.List[PartitionMap]):
-        partition_maps = [x._inner for x in partition_maps]
-        return cls(_TopicSpec.new_computed(partition_maps))
+    def new(cls):
+        return cls(_TopicSpec.new_computed(1, 1, True))
 
     @classmethod
-    def new_computed(cls, partitions: int, replication: int, ignore: bool):
-        return cls(_TopicSpec.new_computed(partitions, replication, ignore))
+    def new_assigned(cls, partition_maps: typing.List[PartitionMap]):
+        partition_maps = [x._inner for x in partition_maps]
+        return cls(_TopicSpec.new_assigned(partition_maps))
+
+    @classmethod
+    def new_computed(cls, partitions: int, replications: int, ignore: bool):
+        return cls(_TopicSpec.new_computed(partitions, replications, ignore))
+
+    @classmethod
+    def new_mirror(cls):
+        return cls(_TopicSpec.new_mirror())
+
+    def set_storage(
+        self, partition_size: typing.Optional[int], segment: typing.Optional[int]
+    ):
+        self._inner.set_storage(partition_size, segment)
+
+    def set_system(self, system: bool):
+        self._inner.set_system(system)
+
+    def set_retention_time(self, retention: int):
+        self._inner.set_retation_time(retention)
+
+    def set_compression_type(self, compression: str):
+        self._inner.set_compression_type(compression)
 
 
 class CommonCreateRequest:

--- a/fluvio/specs.py
+++ b/fluvio/specs.py
@@ -11,7 +11,6 @@ from ._fluvio_python import (
     MetaUpdateTopicSpec as _MetaUpdateTopicSpec,
     MetaUpdateSmartModuleSpec as _MetaUpdateSmartModuleSpec,
     SmartModuleSpec as _SmartModuleSpec,
-    TopicSpec as _TopicSpec,
 )
 
 
@@ -24,44 +23,6 @@ class PartitionMap:
     @classmethod
     def new(cls, partition: int, replicas: typing.List[int]):
         return cls(_PartitionMap.new(partition, replicas))
-
-
-class TopicSpec:
-    _inner: _TopicSpec
-
-    def __init__(self, inner: _TopicSpec):
-        self._inner = inner
-
-    @classmethod
-    def new(cls):
-        return cls(_TopicSpec.new_computed(1, 1, True))
-
-    @classmethod
-    def new_assigned(cls, partition_maps: typing.List[PartitionMap]):
-        partition_maps = [x._inner for x in partition_maps]
-        return cls(_TopicSpec.new_assigned(partition_maps))
-
-    @classmethod
-    def new_computed(cls, partitions: int, replications: int, ignore: bool):
-        return cls(_TopicSpec.new_computed(partitions, replications, ignore))
-
-    @classmethod
-    def new_mirror(cls):
-        return cls(_TopicSpec.new_mirror())
-
-    def set_storage(
-        self, partition_size: typing.Optional[int], segment: typing.Optional[int]
-    ):
-        self._inner.set_storage(partition_size, segment)
-
-    def set_system(self, system: bool):
-        self._inner.set_system(system)
-
-    def set_retention_time(self, retention: int):
-        self._inner.set_retation_time(retention)
-
-    def set_compression_type(self, compression: str):
-        self._inner.set_compression_type(compression)
 
 
 class CommonCreateRequest:

--- a/fluvio/topic.py
+++ b/fluvio/topic.py
@@ -27,13 +27,17 @@ class TopicSpec:
     mode: TopicMode = TopicMode.COMPUTED
     partitions: int = 1
     replications: int = 1
-    ignore_rack: bool = False
+    ignore_rack: bool = True
     replica_assignment: Optional[List[PartitionMap]] = None
     retention_time: Optional[int] = None
     segment_size: Optional[int] = None
     compression_type: Optional[CompressionType] = None
     max_partition_size: Optional[int] = None
     system: bool = False
+
+    @classmethod
+    def new(cls, partitions: int = 1, replication: int = 1, ignore: bool = True):
+        return cls(_TopicSpec.new_computed(partitions, replication, ignore))
 
     @classmethod
     def create(cls) -> "TopicSpec":

--- a/fluvio/topic.py
+++ b/fluvio/topic.py
@@ -1,7 +1,8 @@
 from dataclasses import dataclass, replace
 from typing import Optional, List, Union
 from enum import Enum
-from .specs import TopicSpec, PartitionMap
+from .specs import PartitionMap
+from ._fluvio_python import TopicSpec as _TopicSpec
 from .utils import parse_byte_size
 from humanfriendly import parse_timespan
 
@@ -22,7 +23,7 @@ class CompressionType(Enum):
 
 
 @dataclass(frozen=True)
-class NewTopic:
+class TopicSpec:
     mode: TopicMode = TopicMode.COMPUTED
     partitions: int = 1
     replications: int = 1
@@ -35,41 +36,41 @@ class NewTopic:
     system: bool = False
 
     @classmethod
-    def create(cls) -> "NewTopic":
+    def create(cls) -> "TopicSpec":
         """Alternative constructor method"""
         return cls()
 
-    def with_assignment(self, replica_assignment: List[PartitionMap]) -> "NewTopic":
+    def with_assignment(self, replica_assignment: List[PartitionMap]) -> "TopicSpec":
         """Set the assigned replica configuration"""
         return replace(
             self, mode=TopicMode.ASSIGNED, replica_assignment=replica_assignment
         )
 
-    def as_mirror_topic(self) -> "NewTopic":
+    def as_mirror_topic(self) -> "TopicSpec":
         """Set as a mirror topic"""
         return replace(self, mode=TopicMode.MIRROR)
 
-    def with_partitions(self, partitions: int) -> "NewTopic":
+    def with_partitions(self, partitions: int) -> "TopicSpec":
         """Set the specified partitions"""
         if partitions < 0:
             raise ValueError("Partitions must be a positive integer")
         return replace(self, partitions=partitions)
 
-    def with_replications(self, replications: int) -> "NewTopic":
+    def with_replications(self, replications: int) -> "TopicSpec":
         """Set the specified replication factor"""
         if replications < 0:
             raise ValueError("Replication factor must be a positive integer")
         return replace(self, replications=replications)
 
-    def with_ignore_rack(self, ignore: bool = True) -> "NewTopic":
+    def with_ignore_rack(self, ignore: bool = True) -> "TopicSpec":
         """Set the rack ignore setting"""
         return replace(self, ignore_rack=ignore)
 
-    def with_compression(self, compression: CompressionType) -> "NewTopic":
+    def with_compression(self, compression: CompressionType) -> "TopicSpec":
         """Set the specified compression type"""
         return replace(self, compression_type=compression)
 
-    def with_retention_time(self, retention_time: Union[str, int]) -> "NewTopic":
+    def with_retention_time(self, retention_time: Union[str, int]) -> "TopicSpec":
         """Set the specified retention time"""
 
         if isinstance(retention_time, int):
@@ -78,7 +79,7 @@ class NewTopic:
         parsed_time = parse_timespan(retention_time)
         return replace(self, retention_time=parsed_time)
 
-    def with_segment_size(self, size: Union[str, int]) -> "NewTopic":
+    def with_segment_size(self, size: Union[str, int]) -> "TopicSpec":
         """Set the specified segment size"""
         if isinstance(size, int):
             return replace(self, segment_size=size)
@@ -86,7 +87,7 @@ class NewTopic:
         parsed_size = parse_byte_size(size)
         return replace(self, segment_size=parsed_size)
 
-    def with_max_partition_size(self, size: Union[str, int]) -> "NewTopic":
+    def with_max_partition_size(self, size: Union[str, int]) -> "TopicSpec":
         """Set the specified max partition size"""
         if isinstance(size, int):
             return replace(self, max_partition_size=size)
@@ -94,19 +95,19 @@ class NewTopic:
         parsed_size = parse_byte_size(size)
         return replace(self, max_partition_size=parsed_size)
 
-    def as_system_topic(self, is_system: bool = True) -> "NewTopic":
+    def as_system_topic(self, is_system: bool = True) -> "TopicSpec":
         """Set the topic as an internal system topic"""
         return replace(self, system=is_system)
 
-    def build(self) -> TopicSpec:
+    def build(self) -> _TopicSpec:
         """Build the TopicSpec based on the current configuration"""
         # Similar implementation to the original build method
         if self.mode == TopicMode.ASSIGNED and self.replica_assignment:
-            spec = TopicSpec.new_assigned(self.replica_assignment)
+            spec = _TopicSpec.new_assigned(self.replica_assignment)
         elif self.mode == TopicMode.MIRROR:
-            spec = TopicSpec.new_mirror()
+            spec = _TopicSpec.new_mirror()
         else:
-            spec = TopicSpec.new_computed(
+            spec = _TopicSpec.new_computed(
                 self.partitions, self.replications, self.ignore_rack
             )
 

--- a/fluvio/utils.py
+++ b/fluvio/utils.py
@@ -1,0 +1,8 @@
+from humanfriendly import parse_size
+
+
+def parse_byte_size(size: str) -> int:
+    # if size cotains "ib" then it is binary size else decimal size
+    if "ib" in size.lower():
+        return parse_size(size, binary=True)
+    return parse_size(size, binary=False)

--- a/integration-tests/test_fluvio_python.py
+++ b/integration-tests/test_fluvio_python.py
@@ -7,7 +7,7 @@ import uuid
 
 from string import ascii_lowercase
 from fluvio import Fluvio, Offset, ConsumerConfig, SmartModuleKind, FluvioConfig
-from fluvio import FluvioAdmin, NewTopic
+from fluvio import FluvioAdmin, TopicSpec
 
 
 def create_smartmodule(sm_name, sm_path):
@@ -709,7 +709,7 @@ class TestFluvioAdminTopic(CommonFluvioAdminTestCase):
 
         # create topic
         topic_spec = (
-            NewTopic.create()
+            TopicSpec.create()
             .with_max_partition_size("1Gb")
             .with_retention_time(3600)
             .with_segment_size("10M")

--- a/integration-tests/test_fluvio_python.py
+++ b/integration-tests/test_fluvio_python.py
@@ -7,7 +7,7 @@ import uuid
 
 from string import ascii_lowercase
 from fluvio import Fluvio, Offset, ConsumerConfig, SmartModuleKind, FluvioConfig
-from fluvio import FluvioAdmin, TopicSpec
+from fluvio import FluvioAdmin, NewTopic
 
 
 def create_smartmodule(sm_name, sm_path):
@@ -706,10 +706,16 @@ class TestFluvioAdminTopic(CommonFluvioAdminTestCase):
 
     def test_admin_topic(self):
         fluvio_admin = FluvioAdmin.connect()
-        topic_spec = TopicSpec.new_computed(3, 1, False)
 
         # create topic
-        fluvio_admin.create_topic_spec(self.topic, False, topic_spec)
+        topic_spec = (
+            NewTopic.create()
+            .with_max_partition_size("1Gb")
+            .with_retention_time(3600)
+            .with_segment_size("10M")
+            .build()
+        )
+        fluvio_admin.create_topic(self.topic, topic_spec)
 
         # watch topic
         stream = fluvio_admin.watch_topic()

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ black==24.8.0
 semantic-version==2.10.0
 setuptools-rust==1.10.1
 toml==0.10.2
+humanfriendly==10.0

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 from setuptools import setup, find_namespace_packages
 from setuptools_rust import Binding, RustExtension, Strip
 
+with open('requirements.txt') as f:
+    requirements = f.read().splitlines()
+
 setup(
     name="fluvio",
     version="0.17.0",
@@ -43,6 +46,7 @@ setup(
         )
     ],
     packages=["fluvio"],
+    install_requires=requirements,
     # rust extensions are not zip safe, just like C-extensions.
     zip_safe=False,
 )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1125,6 +1125,10 @@ impl TopicSpec {
         }
     }
 
+    pub fn set_partition(&mut self, system: bool) {
+        self.inner.set_system(system);
+    }
+
     pub fn set_system(&mut self, system: bool) {
         self.inner.set_system(system);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,8 +35,11 @@ use fluvio_sc_schema::objects::{
     MetadataUpdate as NativeMetadataUpdate, WatchResponse as NativeWatchResponse,
 };
 use fluvio_sc_schema::smartmodule::SmartModuleSpec as NativeSmartModuleSpec;
-use fluvio_sc_schema::topic::PartitionMaps as NativePartitionMaps;
-use fluvio_types::PartitionId;
+use fluvio_sc_schema::topic::{
+    CleanupPolicy, CompressionAlgorithm, Deduplication, HomeMirrorConfig, MirrorConfig,
+    PartitionMaps as NativePartitionMaps, ReplicaSpec, SegmentBasedPolicy, TopicStorageConfig,
+};
+use fluvio_types::{compression, PartitionId};
 use fluvio_types::{
     IgnoreRackAssignment as NativeIgnoreRackAssignment, PartitionCount as NativePartitionCount,
     PartitionId as NativePartitionId, ReplicationFactor as NativeReplicationFactor,
@@ -53,7 +56,6 @@ use tracing::info;
 use url::Host;
 mod cloud;
 
-// use crate::error::FluvioError;
 mod consumer;
 mod error;
 mod produce_output;
@@ -1110,6 +1112,58 @@ impl TopicSpec {
         TopicSpec {
             inner: NativeTopicSpec::new_computed(partitions, replications, ignore),
         }
+    }
+
+    #[staticmethod]
+    pub fn new_mirror() -> TopicSpec {
+        let mut home_mirror = HomeMirrorConfig::from(vec![]);
+        //TODO: when update to 0.13.0
+        //home_mirror.source = home_to_remote;
+        let mirror_map = MirrorConfig::Home(home_mirror);
+        TopicSpec {
+            inner: NativeTopicSpec::new_mirror(mirror_map),
+        }
+    }
+
+    pub fn set_system(&mut self, system: bool) {
+        self.inner.set_system(system);
+    }
+
+    pub fn set_retation_time(&mut self, time_in_seconds: i64) {
+        self.inner
+            .set_cleanup_policy(CleanupPolicy::Segment(SegmentBasedPolicy {
+                time_in_seconds: time_in_seconds as u32,
+            }));
+    }
+
+    pub fn set_storage(&mut self, max_partition_size: Option<i64>, segment_size: Option<i64>) {
+        let mut storage = TopicStorageConfig::default();
+
+        if let Some(segment_size) = segment_size {
+            storage.segment_size = Some(segment_size as u32);
+        }
+
+        if let Some(max_partition_size) = max_partition_size {
+            storage.max_partition_size = Some(max_partition_size as u64);
+        }
+
+        self.inner.set_storage(storage);
+    }
+
+    pub fn set_compression_type(&mut self, compression: String) {
+        if compression == "none" {
+            self.inner.set_compression_type(CompressionAlgorithm::None);
+        } else if compression == "gzip" {
+            self.inner.set_compression_type(CompressionAlgorithm::Gzip);
+        } else if compression == "snappy" {
+            self.inner
+                .set_compression_type(CompressionAlgorithm::Snappy);
+        } else if compression == "lz4" {
+            self.inner.set_compression_type(CompressionAlgorithm::Lz4);
+        } else if compression == "zstd" {
+            self.inner.set_compression_type(CompressionAlgorithm::Zstd);
+        }
+        self.inner.set_compression_type(CompressionAlgorithm::Any);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1133,7 +1133,7 @@ impl TopicSpec {
         self.inner.set_system(system);
     }
 
-    pub fn set_retation_time(&mut self, time_in_seconds: i64) {
+    pub fn set_retention_time(&mut self, time_in_seconds: i64) {
         self.inner
             .set_cleanup_policy(CleanupPolicy::Segment(SegmentBasedPolicy {
                 time_in_seconds: time_in_seconds as u32,
@@ -1154,20 +1154,23 @@ impl TopicSpec {
         self.inner.set_storage(storage);
     }
 
-    pub fn set_compression_type(&mut self, compression: String) {
-        if compression == "none" {
-            self.inner.set_compression_type(CompressionAlgorithm::None);
-        } else if compression == "gzip" {
-            self.inner.set_compression_type(CompressionAlgorithm::Gzip);
-        } else if compression == "snappy" {
-            self.inner
-                .set_compression_type(CompressionAlgorithm::Snappy);
-        } else if compression == "lz4" {
-            self.inner.set_compression_type(CompressionAlgorithm::Lz4);
-        } else if compression == "zstd" {
-            self.inner.set_compression_type(CompressionAlgorithm::Zstd);
-        }
-        self.inner.set_compression_type(CompressionAlgorithm::Any);
+    pub fn set_compression_type(&mut self, compression: &str) -> PyResult<()> {
+        let compression = match compression {
+            "none" => CompressionAlgorithm::None,
+            "gzip" => CompressionAlgorithm::Gzip,
+            "snappy" => CompressionAlgorithm::Snappy,
+            "lz4" => CompressionAlgorithm::Lz4,
+            "zstd" => CompressionAlgorithm::Zstd,
+            _ => {
+                return Err(PyValueError::new_err(format!(
+                    "Invalid compression type: {}",
+                    compression
+                )))
+            }
+        };
+
+        self.inner.set_compression_type(compression);
+        Ok(())
     }
 }
 

--- a/tests/test_new_topic.py
+++ b/tests/test_new_topic.py
@@ -1,11 +1,11 @@
 import unittest
 
-from fluvio import NewTopic, TopicMode, CompressionType
+from fluvio import TopicSpec, TopicMode, CompressionType
 
-class TestNewTopic(unittest.TestCase):
+class TestTopicSpec(unittest.TestCase):
     def test_default_creation(self):
         """Test default topic creation"""
-        topic = NewTopic.create()
+        topic = TopicSpec.create()
         
         self.assertEqual(topic.mode, TopicMode.COMPUTED)
         self.assertEqual(topic.partitions, 1)
@@ -20,7 +20,7 @@ class TestNewTopic(unittest.TestCase):
 
     def test_topic_immutability(self):
         """Ensure topic instances are immutable"""
-        topic = NewTopic.create()
+        topic = TopicSpec.create()
         
         # These should create new instances, not modify the original
         topic2 = topic.with_partitions(3)
@@ -34,7 +34,7 @@ class TestNewTopic(unittest.TestCase):
 
     def test_topic_with_methods(self):
         """Test all with_* methods create correct instances"""
-        topic = (NewTopic.create()
+        topic = (TopicSpec.create()
             .with_partitions(3)
             .with_replications(2)
             .with_ignore_rack()
@@ -57,7 +57,7 @@ class TestNewTopic(unittest.TestCase):
     def test_system_topic(self):
         """Test system topic configuration"""
         # Default not system
-        default_topic = NewTopic.create()
+        default_topic = TopicSpec.create()
         self.assertFalse(default_topic.system)
         
         # Explicitly set as system
@@ -71,12 +71,12 @@ class TestNewTopic(unittest.TestCase):
     def test_compression_types(self):
         """Test all compression types can be set"""
         for compression in CompressionType:
-            topic = NewTopic.create().with_compression(compression)
+            topic = TopicSpec.create().with_compression(compression)
             self.assertEqual(topic.compression_type, compression)
 
     def test_chaining_multiple_configurations(self):
         """Test complex chaining of configuration methods"""
-        topic = (NewTopic.create()
+        topic = (TopicSpec.create()
             .with_partitions(5)
             .with_replications(3)
             .as_mirror_topic()
@@ -92,7 +92,7 @@ class TestNewTopic(unittest.TestCase):
 
     def test_with_time_and_size_parsing(self):
         """Test creating topics with parsed time and size"""
-        topic = (NewTopic.create()
+        topic = (TopicSpec.create()
             .with_retention_time('1d')
             .with_segment_size('500M')
             .with_max_partition_size('1G')
@@ -102,7 +102,7 @@ class TestNewTopic(unittest.TestCase):
         self.assertEqual(topic.segment_size, 500 * 1000 * 1000)
         self.assertEqual(topic.max_partition_size, 1000 * 1000 * 1000)
 
-        topic = (NewTopic.create()
+        topic = (TopicSpec.create()
             .with_retention_time('2m')
             .with_segment_size('500mb')
             .with_max_partition_size('1gb')
@@ -112,7 +112,7 @@ class TestNewTopic(unittest.TestCase):
         self.assertEqual(topic.segment_size, 500 * 1000 * 1000)
         self.assertEqual(topic.max_partition_size, 1000 * 1000 * 1000)
 
-        topic = (NewTopic.create()
+        topic = (TopicSpec.create()
             .with_retention_time('3h')
             .with_segment_size('500MiB')
             .with_max_partition_size('1GiB')
@@ -123,7 +123,7 @@ class TestNewTopic(unittest.TestCase):
         self.assertEqual(topic.max_partition_size, 1024 * 1024 * 1024)
 
 
-        topic = (NewTopic.create()
+        topic = (TopicSpec.create()
             .with_retention_time('4s')
             .with_segment_size('500MB')
             .with_max_partition_size('1GB')
@@ -136,7 +136,7 @@ class TestNewTopic(unittest.TestCase):
 
     def test_with_numeric_inputs(self):
         """Test creating topics with numeric inputs"""
-        topic = (NewTopic.create()
+        topic = (TopicSpec.create()
             .with_retention_time(3600)
             .with_segment_size(1024 * 1024)
             .with_max_partition_size(2 * 1024 * 1024 * 1024)
@@ -150,10 +150,10 @@ class TestNewTopic(unittest.TestCase):
     def test_invalid_configurations(self):
         """Test handling of potentially invalid configurations"""
         with self.assertRaises(ValueError):
-            NewTopic.create().with_partitions(-1)
+            TopicSpec.create().with_partitions(-1)
         
         with self.assertRaises(ValueError):
-            NewTopic.create().with_replications(-1)
+            TopicSpec.create().with_replications(-1)
 
 
 if __name__ == '__main__':

--- a/tests/test_new_topic.py
+++ b/tests/test_new_topic.py
@@ -1,0 +1,160 @@
+import unittest
+
+from fluvio import NewTopic, TopicMode, CompressionType
+
+class TestNewTopic(unittest.TestCase):
+    def test_default_creation(self):
+        """Test default topic creation"""
+        topic = NewTopic.create()
+        
+        self.assertEqual(topic.mode, TopicMode.COMPUTED)
+        self.assertEqual(topic.partitions, 1)
+        self.assertEqual(topic.replications, 1)
+        self.assertFalse(topic.ignore_rack)
+        self.assertIsNone(topic.replica_assignment)
+        self.assertIsNone(topic.retention_time)
+        self.assertIsNone(topic.segment_size)
+        self.assertIsNone(topic.compression_type)
+        self.assertIsNone(topic.max_partition_size)
+        self.assertFalse(topic.system)
+
+    def test_topic_immutability(self):
+        """Ensure topic instances are immutable"""
+        topic = NewTopic.create()
+        
+        # These should create new instances, not modify the original
+        topic2 = topic.with_partitions(3)
+        topic3 = topic.with_replications(2)
+        
+        self.assertIsNot(topic, topic2)
+        self.assertIsNot(topic, topic3)
+        self.assertEqual(topic.partitions, 1)  # Original remains unchanged
+        self.assertEqual(topic2.partitions, 3)
+        self.assertEqual(topic3.replications, 2)
+
+    def test_topic_with_methods(self):
+        """Test all with_* methods create correct instances"""
+        topic = (NewTopic.create()
+            .with_partitions(3)
+            .with_replications(2)
+            .with_ignore_rack()
+            .with_retention_time(86400)
+            .with_segment_size(1024)
+            .with_compression(CompressionType.GZIP)
+            .with_max_partition_size(2048)
+            .as_system_topic()
+        )
+        
+        self.assertEqual(topic.partitions, 3)
+        self.assertEqual(topic.replications, 2)
+        self.assertTrue(topic.ignore_rack)
+        self.assertEqual(topic.retention_time, 86400)
+        self.assertEqual(topic.segment_size, 1024)
+        self.assertEqual(topic.compression_type, CompressionType.GZIP)
+        self.assertEqual(topic.max_partition_size, 2048)
+        self.assertTrue(topic.system)
+
+    def test_system_topic(self):
+        """Test system topic configuration"""
+        # Default not system
+        default_topic = NewTopic.create()
+        self.assertFalse(default_topic.system)
+        
+        # Explicitly set as system
+        system_topic = default_topic.as_system_topic()
+        self.assertTrue(system_topic.system)
+        
+        # Optional parameter for non-system
+        non_system_topic = default_topic.as_system_topic(False)
+        self.assertFalse(non_system_topic.system)
+
+    def test_compression_types(self):
+        """Test all compression types can be set"""
+        for compression in CompressionType:
+            topic = NewTopic.create().with_compression(compression)
+            self.assertEqual(topic.compression_type, compression)
+
+    def test_chaining_multiple_configurations(self):
+        """Test complex chaining of configuration methods"""
+        topic = (NewTopic.create()
+            .with_partitions(5)
+            .with_replications(3)
+            .as_mirror_topic()
+            .with_retention_time(172800)  # 2 days
+            .as_system_topic()
+        )
+        
+        self.assertEqual(topic.mode, TopicMode.MIRROR)
+        self.assertEqual(topic.partitions, 5)
+        self.assertEqual(topic.replications, 3)
+        self.assertEqual(topic.retention_time, 172800)
+        self.assertTrue(topic.system) 
+
+    def test_with_time_and_size_parsing(self):
+        """Test creating topics with parsed time and size"""
+        topic = (NewTopic.create()
+            .with_retention_time('1d')
+            .with_segment_size('500M')
+            .with_max_partition_size('1G')
+        )
+        
+        self.assertEqual(topic.retention_time, 86400)
+        self.assertEqual(topic.segment_size, 500 * 1000 * 1000)
+        self.assertEqual(topic.max_partition_size, 1000 * 1000 * 1000)
+
+        topic = (NewTopic.create()
+            .with_retention_time('2m')
+            .with_segment_size('500mb')
+            .with_max_partition_size('1gb')
+        )
+
+        self.assertEqual(topic.retention_time, 2 * 60)
+        self.assertEqual(topic.segment_size, 500 * 1000 * 1000)
+        self.assertEqual(topic.max_partition_size, 1000 * 1000 * 1000)
+
+        topic = (NewTopic.create()
+            .with_retention_time('3h')
+            .with_segment_size('500MiB')
+            .with_max_partition_size('1GiB')
+        )
+
+        self.assertEqual(topic.retention_time, 3 * 3600) 
+        self.assertEqual(topic.segment_size, 500 * 1024 * 1024)
+        self.assertEqual(topic.max_partition_size, 1024 * 1024 * 1024)
+
+
+        topic = (NewTopic.create()
+            .with_retention_time('4s')
+            .with_segment_size('500MB')
+            .with_max_partition_size('1GB')
+        )
+        
+        self.assertEqual(topic.retention_time, 4)
+        self.assertEqual(topic.segment_size, 500 * 1000 * 1000)
+        self.assertEqual(topic.max_partition_size, 1000 * 1000 * 1000)
+
+
+    def test_with_numeric_inputs(self):
+        """Test creating topics with numeric inputs"""
+        topic = (NewTopic.create()
+            .with_retention_time(3600)
+            .with_segment_size(1024 * 1024)
+            .with_max_partition_size(2 * 1024 * 1024 * 1024)
+        )
+        
+        # Verify numeric inputs
+        self.assertEqual(topic.retention_time, 3600)
+        self.assertEqual(topic.segment_size, 1024 * 1024)
+        self.assertEqual(topic.max_partition_size, 2 * 1024 * 1024 * 1024)
+
+    def test_invalid_configurations(self):
+        """Test handling of potentially invalid configurations"""
+        with self.assertRaises(ValueError):
+            NewTopic.create().with_partitions(-1)
+        
+        with self.assertRaises(ValueError):
+            NewTopic.create().with_replications(-1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_topic.py
+++ b/tests/test_topic.py
@@ -10,7 +10,7 @@ class TestTopicSpec(unittest.TestCase):
         self.assertEqual(topic.mode, TopicMode.COMPUTED)
         self.assertEqual(topic.partitions, 1)
         self.assertEqual(topic.replications, 1)
-        self.assertFalse(topic.ignore_rack)
+        self.assertTrue(topic.ignore_rack)
         self.assertIsNone(topic.replica_assignment)
         self.assertIsNone(topic.retention_time)
         self.assertIsNone(topic.segment_size)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,37 @@
+import unittest
+
+from fluvio.utils import parse_byte_size
+from humanfriendly import InvalidSize
+
+
+class TestParsing(unittest.TestCase):
+    def test_parse_byte_size(self):
+        """Test byte size string parsing"""
+        # Direct bytes
+        self.assertEqual(parse_byte_size('1024'), 1024)
+
+        # Kilobytes
+        self.assertEqual(parse_byte_size('1K'), 1000)
+        self.assertEqual(parse_byte_size('2K'), 2 * 1000)
+
+        # Megabytes
+        self.assertEqual(parse_byte_size('1M'), 1000 * 1000)
+        self.assertEqual(parse_byte_size('1Mib'), 1024 * 1024)
+        self.assertEqual(parse_byte_size('1MiB'), 1024 * 1024)
+        self.assertEqual(parse_byte_size('500M'), 500 * 1000 * 1000)
+        self.assertEqual(parse_byte_size('500MiB'), 500 * 1024 * 1024)
+
+        # Gigabytes
+        self.assertEqual(parse_byte_size('1G'), 1000 * 1000 * 1000)
+        self.assertEqual(parse_byte_size('2G'), 2 * 1000 * 1000 * 1000)
+        self.assertEqual(parse_byte_size('2Gib'), 2 * 1024 * 1024 * 1024)
+
+        # Terabytes
+        self.assertEqual(parse_byte_size('1T'), 1000 * 1000 * 1000 * 1000)
+        self.assertEqual(parse_byte_size('1TiB'), 1024 * 1024 * 1024 * 1024)
+
+        # Invalid formats
+        with self.assertRaises(InvalidSize):
+            parse_byte_size('1x')
+        with self.assertRaises(InvalidSize):
+            parse_byte_size('abc')


### PR DESCRIPTION
Simple (1 partition and 1 replica):
```python
fluvio_admin = FluvioAdmin.connect()
fluvio_admin.create_topic("topic_name")
```

or

```python
fluvio_admin = FluvioAdmin.connect()
topic_spec = TopicSpec.new()
fluvio_admin.create_topic("topic_name", topic_spec)
```

Advanced:
```python
fluvio_admin = FluvioAdmin.connect()
topic_spec = (
    TopicSpec.create()
    .with_partitions(3)
    .with_replications(3)
    .with_max_partition_size("1Gb")
    .with_retention_time(3600)
    .with_segment_size("10M")
    .as_system_topic()
    .build()
)
fluvio_admin.create_topic("topic_name", topic_spec)
```

~I am using `NewTopic` only because [kafka-python](https://github.com/dpkp/kafka-python) also uses a class called `NewTopic`~