### PR TITLE
feat: add graceful shutdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest] # TODO: add windows-2019,
-        python-version: ["39", "310", "311", "312"]
+        python-version: ["39", "310", "311", "312", "313"]
     env:
       CIBW_SKIP: "cp36-* pp* *-win32"
       CIBW_ARCHS_MACOS: x86_64 universal2 arm64
@@ -44,7 +44,7 @@ jobs:
       # Used to host cibuildwheel
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - if: runner.os == 'macOS'
         name: Install rust toolchain
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - name: Install Rust ${{ matrix.platform.target }}
         uses: dtolnay/rust-toolchain@master
         with:
@@ -133,7 +133,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         rust: [stable]
-        python-version: ["3.12"]
+        python-version: ["3.13"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4
@@ -167,7 +167,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         rust: [stable]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4
@@ -240,7 +240,7 @@ jobs:
       matrix:
         os: [macos-latest]
         rust: [stable]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Install rust ${{ matrix.rust }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         rust: [stable]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4

--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         rust: [stable]
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.9", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4

--- a/.github/workflows/latest-dev-fluvio.yaml
+++ b/.github/workflows/latest-dev-fluvio.yaml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         rust: [stable]
-        python-version: ["3.12"]
+        python-version: ["3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Install rust ${{ matrix.rust }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest] # TODO: add windows-2019,
-        python-version: ["38", "39", "310", "311", "312"]
+        python-version: ["38", "39", "310", "311", "312", "313"]
     env:
       CIBW_SKIP: "cp36-* pp* *-win32"
       CIBW_ARCHS_MACOS: x86_64 universal2 arm64
@@ -38,7 +38,7 @@ jobs:
       # Used to host cibuildwheel
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - if: runner.os == 'macOS'
         name: Install rust toolchain
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install setuptools and setuptools-rust
         run: |
@@ -126,7 +126,7 @@ jobs:
       - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - name: Install Rust ${{ matrix.platform.target }}
         uses: dtolnay/rust-toolchain@master
         with:
@@ -178,7 +178,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.12"]
+        python-version: ["3.13"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ futures = "0.3.30"
 hex = "0.4.2"
 http-types = "2.6.0"
 md-5 = "0.10.0"
-pyo3 = { version = "0.20.2", features = ["extension-module"] }
-pyo3-asyncio = { version = "0.20.0", features = ["testing", "attributes", "async-std-runtime"] }
+pyo3 = { version = "0.23.3", features = ["extension-module"] }
+pyo3-async-runtimes = { version = "0.23", features = ["attributes", "async-std-runtime"] }
 rpassword = "7.3.1"
 serde = "1.0.117"
 serde_json = "1.0.59"

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ integration-tests: build-dev
 test-signals: build-dev
 	cd integration-tests/ && $(PYTHON) -m unittest test_signals.py
 
+test-signals-async: build-dev
+	cd integration-tests/ && $(PYTHON) -m unittest test_signals_async.py
+
 test-produce: build-dev
 	cd integration-tests/ &&  $(PYTHON) -m unittest test_produce.py
 

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,9 @@ unit-tests: build-dev
 integration-tests: build-dev
 	cd integration-tests/ && $(PYTHON) -m unittest
 
+test-signals: build-dev
+	cd integration-tests/ && $(PYTHON) -m unittest test_signals.py
+
 test-produce: build-dev
 	cd integration-tests/ &&  $(PYTHON) -m unittest test_produce.py
 

--- a/integration-tests/test_fluvio_python.py
+++ b/integration-tests/test_fluvio_python.py
@@ -577,7 +577,8 @@ class TestFluvioMethods(CommonFluvioSmartModuleTestCase):
             self.assertEqual(bytearray(i.value()).decode(), "record-%s" % count)
             self.assertEqual(i.value_string(), "record-%s" % count)
             self.assertEqual(i.key_string(), "foo")
-            self.assertEqual(i.key(), list("foo".encode()))
+            # self.assertEqual(i.key(), list("foo".encode()))
+            self.assertEqual(i.key(), b'foo')
 
     def test_record_timestamp(self):
         fluvio = Fluvio.connect()
@@ -606,7 +607,7 @@ class TestFluvioMethods(CommonFluvioSmartModuleTestCase):
             self.assertEqual(bytearray(i.value()).decode(), "record-%s" % count)
             self.assertEqual(i.value_string(), "record-%s" % count)
             self.assertEqual(i.key_string(), ("%s" % count))
-            self.assertEqual(i.key(), list(("%s" % count).encode()))
+            self.assertEqual(i.key(), ("%s" % count).encode())
 
 
 class TestFluvioErrors(CommonFluvioSmartModuleTestCase):

--- a/integration-tests/test_fluvio_python.py
+++ b/integration-tests/test_fluvio_python.py
@@ -578,7 +578,7 @@ class TestFluvioMethods(CommonFluvioSmartModuleTestCase):
             self.assertEqual(i.value_string(), "record-%s" % count)
             self.assertEqual(i.key_string(), "foo")
             # self.assertEqual(i.key(), list("foo".encode()))
-            self.assertEqual(i.key(), b'foo')
+            self.assertEqual(i.key(), b"foo")
 
     def test_record_timestamp(self):
         fluvio = Fluvio.connect()

--- a/integration-tests/test_fluvio_python.py
+++ b/integration-tests/test_fluvio_python.py
@@ -577,7 +577,6 @@ class TestFluvioMethods(CommonFluvioSmartModuleTestCase):
             self.assertEqual(bytearray(i.value()).decode(), "record-%s" % count)
             self.assertEqual(i.value_string(), "record-%s" % count)
             self.assertEqual(i.key_string(), "foo")
-            # self.assertEqual(i.key(), list("foo".encode()))
             self.assertEqual(i.key(), b"foo")
 
     def test_record_timestamp(self):

--- a/integration-tests/test_signals.py
+++ b/integration-tests/test_signals.py
@@ -1,0 +1,124 @@
+import os
+import time
+import multiprocessing
+import signal
+
+from enum import Enum
+from fluvio import ConsumerConfig, Fluvio, Offset, ConsumerConfigExtBuilder
+from test_base import CommonFluvioSetup  # Ensure this is correctly imported
+
+
+# Explicitly set the start method for multiprocessing
+multiprocessing.set_start_method("spawn", force=True)
+
+
+class ConsumerMode(Enum):
+    STREAM = "stream"
+    STREAM_WITH_OFFSET = "stream_with_offset"
+    CONSUMER_WITH_CONFIG = "consumer_with_config"
+
+
+def consumer_process(topic, control_queue, consumer_mode: ConsumerMode):
+    """
+    Function to run in a separate process that consumes messages.
+    It listens for SIGINT and SIGTERM signals and exits gracefully.
+    """
+    fluvio = Fluvio.connect()
+
+    stream = None
+    if consumer_mode == ConsumerMode.STREAM:
+        consumer = fluvio.partition_consumer(topic, 0)
+        config = ConsumerConfig()
+        stream = consumer.stream_with_config(Offset.beginning(), config)
+    elif consumer_mode == ConsumerMode.STREAM_WITH_OFFSET:
+        consumer = fluvio.partition_consumer(topic, 0)
+        config = ConsumerConfig()
+        stream = consumer.stream(Offset.beginning())
+    elif consumer_mode == ConsumerMode.CONSUMER_WITH_CONFIG:
+        builder = ConsumerConfigExtBuilder(topic)
+        config = builder.build()
+        stream = fluvio.consumer_with_config(config)
+
+    records = []
+    print("Consuming records...")
+    for _ in range(3):
+        try:
+            record = next(stream)
+            records.append(bytearray(record.value()).decode())
+            print("1")
+        except StopIteration:
+            # No more records in the stream
+            print("No more records to consume.")
+            break
+        except KeyboardInterrupt:
+            print("Received SIGINT. Exiting gracefully.")
+            control_queue.put({"status": "interrupted"})
+            return
+        except Exception as e:
+            # Handle other exceptions if necessary
+            control_queue.put({"status": "error", "message": str(e)})
+            return
+    print(f"Consumed {len(records)} records.")
+    # Simulate some processing time to allow signal handling
+    time.sleep(5)
+
+
+class TestFluvioConsumerSignals(CommonFluvioSetup):
+    def setUp(self):
+        self.common_setup()
+
+    def test_consume_with_sigterm(self):
+        """
+        Test that the consumer handles SIGTERM gracefully for multiple consumer modes.
+        """
+        consumer_modes = [
+            ConsumerMode.STREAM,
+            ConsumerMode.STREAM_WITH_OFFSET,
+            ConsumerMode.CONSUMER_WITH_CONFIG,
+        ]
+
+        for mode in consumer_modes:
+            with self.subTest(mode=mode):
+                control_queue = multiprocessing.Queue()
+                process = multiprocessing.Process(
+                    target=consumer_process, args=(self.topic, control_queue, mode)
+                )
+                process.start()
+
+                # Allow some time for the consumer to start and consume some records
+                time.sleep(2)
+
+                pid = process.pid
+                if pid is not None:
+                    print(f"Sending SIGTERM to process {pid}")
+                    os.kill(pid, signal.SIGINT)
+
+                # Wait for the process to handle the signal
+                process.join(timeout=10)
+
+                # Ensure the process has terminated
+                self.assertFalse(
+                    process.is_alive(), "Consumer process should have terminated."
+                )
+
+                # Retrieve results from the queue
+                try:
+                    result = control_queue.get_nowait()
+                except Exception as e:
+                    self.fail(f"No result was returned from the consumer process. {e}")
+
+                # Validate the result based on the status
+                if result["status"] == "success":
+                    records = result.get("records", [])
+                    self.assertTrue(
+                        len(records) <= 3, "Consumed more records than expected."
+                    )
+                elif result["status"] == "interrupted":
+                    # The consumer was interrupted gracefully
+                    self.assertTrue(True)  # Test passes as interruption was handled
+                elif result["status"] == "error":
+                    self.fail(
+                        f"Consumer process encountered an error: {result['message']}"
+                    )
+                else:
+                    self.fail("Consumer process returned an unknown status.")

--- a/integration-tests/test_signals.py
+++ b/integration-tests/test_signals.py
@@ -66,6 +66,11 @@ def consumer_process(topic, control_queue, consumer_mode: ConsumerMode):
 class TestFluvioConsumerSignals(CommonFluvioSetup):
     def setUp(self):
         self.common_setup()
+        # Generate a set of test data for the topic
+        producer = self.fluvio.topic_producer(self.topic)
+        for i in range(2):
+            producer.send_string(f"record-{i}")
+        producer.flush()
 
     def test_consume_with_sigterm(self):
         """

--- a/integration-tests/test_signals_async.py
+++ b/integration-tests/test_signals_async.py
@@ -1,0 +1,177 @@
+import os
+import time
+import multiprocessing
+import signal
+import unittest
+import uuid
+import asyncio
+
+from enum import Enum
+from fluvio import ConsumerConfig, Fluvio, FluvioAdmin, Offset
+
+
+class ConsumerModeAsync(Enum):
+    STREAM_ASYNC = "stream_async"
+    STREAM_WITH_OFFSET_ASYNC = "stream_with_offset_async"
+
+
+async def consumer_process_async(
+    topic, control_queue, consumer_mode: ConsumerModeAsync
+):
+    """
+    Function to run in a separate process that consumes messages asynchronously.
+    It listens for SIGINT and SIGTERM signals and exits gracefully.
+    """
+    fluvio = Fluvio.connect()
+
+    stream = None
+    if consumer_mode == ConsumerModeAsync.STREAM_ASYNC:
+        consumer = fluvio.partition_consumer(topic, 0)
+        config = ConsumerConfig()
+        # async_stream_with_config is an async call
+        stream = await consumer.async_stream_with_config(Offset.beginning(), config)
+    elif consumer_mode == ConsumerModeAsync.STREAM_WITH_OFFSET_ASYNC:
+        consumer = fluvio.partition_consumer(topic, 0)
+        config = ConsumerConfig()
+        # async_stream is an async call
+        stream = await consumer.async_stream(Offset.beginning())
+
+    records = []
+    print("Consuming records...")
+    # async for record in stream:
+    for _ in range(3):
+        try:
+            # In Fluvio, record.value() returns a buffer
+            record = await stream.__anext__()
+            records.append(bytearray(record.value()).decode())
+        except StopIteration:
+            # No more records in the stream
+            print("No more records to consume.")
+            break
+        except KeyboardInterrupt:
+            print("Received SIGINT. Exiting gracefully.")
+            control_queue.put({"status": "interrupted"})
+            return
+        except Exception as e:
+            # Handle other exceptions if necessary
+            control_queue.put({"status": "error", "message": str(e)})
+            return
+
+    print(f"Consumed {len(records)} records.")
+    # You could put successful results on queue if desired
+    control_queue.put({"status": "success", "records": records})
+
+    # Simulate some processing time to allow signal handling
+    time.sleep(5)
+
+
+def consumer_process_async_wrapper(topic, control_queue, consumer_mode):
+    """
+    Synchronous wrapper that runs the async consumer function in an event loop.
+    This is what gets called by the multiprocessing.Process.
+    """
+
+    try:
+        asyncio.run(consumer_process_async(topic, control_queue, consumer_mode))
+    except KeyboardInterrupt:
+        print("Received SIGINT. Exiting gracefully.")
+        control_queue.put({"status": "interrupted"})
+    except Exception as e:
+        print(f"Error in consumer_process_async_wrapper: {e}")
+        control_queue.put({"status": "error", "message": str(e)})
+
+
+class TestFluvioConsumerSignalsAsync(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.admin = FluvioAdmin.connect()
+        self.fluvio = Fluvio.connect()
+        self.topic = str(uuid.uuid4())
+        self.consumer_id = str(uuid.uuid4())
+        self.sm_name = str(uuid.uuid4())
+
+        try:
+            self.admin.create_topic(self.topic)
+        except Exception as err:
+            print("create_topic error {}, will try to verify".format(err))
+
+        # list topics to verify topic was created
+        max_retries = 100
+        while max_retries > 0:
+            topic = self.admin.list_topics([self.topic])
+            if len(topic) > 0:
+                break
+            max_retries -= 1
+            if max_retries == 0:
+                self.fail("setup: Failed to create topic")
+            time.sleep(0.1)
+
+        # Generate a set of test data for the topic
+        producer = self.fluvio.topic_producer(self.topic)
+        for i in range(2):
+            producer.send_string(f"record-{i}")
+        producer.flush()
+
+    def tearDown(self):
+        self.admin.delete_topic(self.topic)
+        # Remove consumer offset if needed
+        self.fluvio.delete_consumer_offset(self.consumer_id, self.topic, 0)
+        time.sleep(1)
+
+    def test_consume_with_sigterm_async(self):
+        """
+        Test that the consumer handles SIGINT (or SIGTERM) gracefully for multiple consumer modes.
+        """
+        consumer_modes = [
+            ConsumerModeAsync.STREAM_ASYNC,
+            ConsumerModeAsync.STREAM_WITH_OFFSET_ASYNC,
+        ]
+
+        for mode in consumer_modes:
+            with self.subTest(mode=mode):
+                control_queue = multiprocessing.Queue()
+                # NOTE: we now point to consumer_process_async_wrapper (sync),
+                #       rather than consumer_process_async (async).
+                process = multiprocessing.Process(
+                    target=consumer_process_async_wrapper,
+                    args=(self.topic, control_queue, mode),
+                )
+                process.start()
+
+                # Allow some time for the consumer to start and consume some records
+                time.sleep(3)
+
+                pid = process.pid
+                if pid is not None:
+                    print(f"Sending SIGINT to process {pid}")
+                    os.kill(pid, signal.SIGINT)
+
+                # Wait for the process to handle the signal
+                process.join(timeout=10)
+
+                # Ensure the process has terminated
+                self.assertFalse(
+                    process.is_alive(), "Consumer process should have terminated."
+                )
+
+                # Retrieve results from the queue
+                try:
+                    result = control_queue.get_nowait()
+                except Exception as e:
+                    self.fail(f"No result was returned from the consumer process. {e}")
+
+                # Validate the result based on the status
+                if result["status"] == "success":
+                    records = result.get("records", [])
+                    # Just an example check
+                    self.assertTrue(
+                        len(records) >= 0, "Expected some records or possibly none."
+                    )
+                elif result["status"] == "interrupted":
+                    # The consumer was interrupted gracefully
+                    self.assertTrue(True)  # Test passes as interruption was handled
+                elif result["status"] == "error":
+                    self.fail(
+                        f"Consumer process encountered an error: {result['message']}"
+                    )
+                else:
+                    self.fail("Consumer process returned an unknown status.")

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: 3 :: Only",
     ],
     rust_extensions=[

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     long_description_content_type="text/markdown",
     author="Fluvio Contributors",
     description="Python client library for Fluvio",
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     url="https://www.fluvio.io/",
     keywords=["fluvio", "streaming", "stream"],
     license="APACHE",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -684,7 +684,7 @@ impl PartitionConsumerIterator {
                 err => Err(PyException::new_err(err.to_string())),
             },
             Ok(None) => Ok(None),
-            Err(err) => Err(PyException::new_err(err.to_string())),
+            Err(err) => Err(err), // Python exception
         }
     }
 }
@@ -707,7 +707,7 @@ impl PartitionConsumerStream {
                 err => Err(PyException::new_err(err.to_string())),
             },
             Ok(None) => Ok(None),
-            Err(err) => Err(PyException::new_err(err.to_string())),
+            Err(err) => Err(err), // Python exception
         }
     }
 
@@ -1620,8 +1620,8 @@ fn run_future_checking_signals<'a, T>(
                     return Ok(res);
                 }
 
-                // Sleep for 1 second intervals to periodically check for signals
-                _ = sleep(Duration::from_secs(1)) => {
+                // Sleep for 100 ms to periodically check for signals
+                _ = sleep(Duration::from_millis(100)) => {
                     // Check for Python signals (like KeyboardInterrupt)
                     py.check_signals()?;
                 }

--- a/src/produce_output.rs
+++ b/src/produce_output.rs
@@ -36,9 +36,9 @@ impl ProduceOutput {
             .transpose()
     }
 
-    fn async_wait<'b>(&'b mut self, py: Python<'b>) -> PyResult<&'b PyAny> {
+    fn async_wait<'b>(&'b mut self, py: Python<'b>) -> PyResult<Bound<'b, PyAny>> {
         let inner = self.inner.take();
-        pyo3_asyncio::async_std::future_into_py(py, async move {
+        pyo3_async_runtimes::async_std::future_into_py(py, async move {
             let record_metadata = match inner {
                 Some(produce_output) => {
                     let pout = produce_output


### PR DESCRIPTION
- [x] add graceful shutdown for consumer methods
- [x] update pyo3 from 0.20.2 to 0.23.3
- [x] replace pyo3-asyncio by pyo3-async-runtimes because it was abandoned
- [x] compatible with python 3.13 (pyo3 was blocking it) https://github.com/infinyon/fluvio/issues/4310
- [x] ci for python 3.13
- [x] create e2e tests 