### PR TITLE
test: fix cloud tests using old consumers

### DIFF
--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -53,7 +53,12 @@ jobs:
           FLUVIO_CLOUD_TEST_USERNAME: ${{ secrets.FLUVIO_CLOUD_TEST_USERNAME }}
           FLUVIO_CLOUD_TEST_PASSWORD: ${{ secrets.FLUVIO_CLOUD_TEST_PASSWORD }}
 
-      - name: Run unit tests
+      - name: Unit Tests
+        env:
+          FLV_SOCKET_WAIT: 300
+        run: |
+          make unit-tests
+      - name: Run Integration Tests
         run: |
           make integration-tests
         env:

--- a/integration-tests/test_consume.py
+++ b/integration-tests/test_consume.py
@@ -87,11 +87,16 @@ class TestFluvioConsumer(CommonFluvioSetup):
         self.assertEqual(records[1], "record-y")
 
         consumers = fluvio.consumer_offsets()
-        self.assertEqual(len(consumers), 1)
-        self.assertEqual(consumers[0].consumer_id, self.consumer_id)
-        self.assertEqual(consumers[0].topic, self.topic)
-        self.assertEqual(consumers[0].partition, 0)
-        self.assertEqual(consumers[0].offset, 1)
+        consumer = next(
+            (c for c in consumers if c.consumer_id == self.consumer_id), None
+        )
+        if consumer is None:
+            self.fail("consumer not found")
+
+        self.assertEqual(consumer.consumer_id, self.consumer_id)
+        self.assertEqual(consumer.topic, self.topic)
+        self.assertEqual(consumer.partition, 0)
+        self.assertEqual(consumer.offset, 1)
 
     def test_consume_offset_managed_auto_commit_and_flush(self):
         """
@@ -118,11 +123,16 @@ class TestFluvioConsumer(CommonFluvioSetup):
         self.assertEqual(records[1], "record-y")
 
         consumers = fluvio.consumer_offsets()
-        self.assertEqual(len(consumers), 1)
-        self.assertEqual(consumers[0].consumer_id, self.consumer_id)
-        self.assertEqual(consumers[0].topic, self.topic)
-        self.assertEqual(consumers[0].partition, 0)
-        self.assertEqual(consumers[0].offset, 1)
+        consumer = next(
+            (c for c in consumers if c.consumer_id == self.consumer_id), None
+        )
+        if consumer is None:
+            self.fail("consumer not found")
+
+        self.assertEqual(consumer.consumer_id, self.consumer_id)
+        self.assertEqual(consumer.topic, self.topic)
+        self.assertEqual(consumer.partition, 0)
+        self.assertEqual(consumer.offset, 1)
 
     def test_consume_offset_managed_auto_flush(self):
         """
@@ -188,11 +198,16 @@ class TestFluvioConsumer(CommonFluvioSetup):
         self.assertEqual(records[0], "record-y")
 
         consumers = fluvio.consumer_offsets()
-        self.assertEqual(len(consumers), 1)
-        self.assertEqual(consumers[0].consumer_id, self.consumer_id)
-        self.assertEqual(consumers[0].topic, self.topic)
-        self.assertEqual(consumers[0].partition, 0)
-        self.assertEqual(consumers[0].offset, 1)
+        consumer = next(
+            (c for c in consumers if c.consumer_id == self.consumer_id), None
+        )
+        if consumer is None:
+            self.fail("consumer not found")
+
+        self.assertEqual(consumer.consumer_id, self.consumer_id)
+        self.assertEqual(consumer.topic, self.topic)
+        self.assertEqual(consumer.partition, 0)
+        self.assertEqual(consumer.offset, 1)
 
     def test_consume_at_offset_from_begin(self):
         fluvio = Fluvio.connect()

--- a/integration-tests/test_signals.py
+++ b/integration-tests/test_signals.py
@@ -45,7 +45,6 @@ def consumer_process(topic, control_queue, consumer_mode: ConsumerMode):
         try:
             record = next(stream)
             records.append(bytearray(record.value()).decode())
-            print("1")
         except StopIteration:
             # No more records in the stream
             print("No more records to consume.")

--- a/integration-tests/test_signals_async.py
+++ b/integration-tests/test_signals_async.py
@@ -86,7 +86,6 @@ class TestFluvioConsumerSignalsAsync(unittest.IsolatedAsyncioTestCase):
         self.admin = FluvioAdmin.connect()
         self.fluvio = Fluvio.connect()
         self.topic = str(uuid.uuid4())
-        self.consumer_id = str(uuid.uuid4())
         self.sm_name = str(uuid.uuid4())
 
         try:
@@ -113,8 +112,6 @@ class TestFluvioConsumerSignalsAsync(unittest.IsolatedAsyncioTestCase):
 
     def tearDown(self):
         self.admin.delete_topic(self.topic)
-        # Remove consumer offset if needed
-        self.fluvio.delete_consumer_offset(self.consumer_id, self.topic, 0)
         time.sleep(1)
 
     def test_consume_with_sigterm_async(self):


### PR DESCRIPTION
The ci for cloud uses the same cluster.

This changes make the test pass even one consumer it was not deleted right.

Probably because it: https://github.com/infinyon/fluvio/issues/4308
Or a shutdown without handling teardown.